### PR TITLE
Bug: Mismatched p and li font sizes

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -384,7 +384,6 @@ p.lead {
 }
 p {
   font-family: inherit;
-  font-size: 1rem;
   font-weight: 400;
   margin-bottom: 1.25rem;
   text-rendering: optimizeLegibility;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -341,7 +341,6 @@ p.lead {
 }
 p {
     font-family: inherit;
-    font-size: 1rem;
     font-weight: 400;
     margin-bottom: 1.25rem;
     text-rendering: optimizeLegibility;


### PR DESCRIPTION
Theme was overriding paragraph font size leading to inconsistent sizing between paragraphs and lists. Removed override. We can adjust font size globally in the future, if we want to.