### PR TITLE
Task: Remove stats menu item.

### DIFF
--- a/ckanext/ontario_theme/templates/header.html
+++ b/ckanext/ontario_theme/templates/header.html
@@ -32,7 +32,6 @@
   {{ h.build_nav_main(
     ('search', _('Datasets')),
     ('organizations_index', _('Organizations')),
-    ('stats', _('Statistics')),
     ('home.about', _('About'))
   ) }}
 {% endblock %}


### PR DESCRIPTION
Remove as per user testing findings and for current
html5 shim error in CKAN (already patched for next release).