### PR TITLE
Bug: Missing attribute error on query.

### DIFF
--- a/ckanext/ontario_theme/templates/snippets/search_form.html
+++ b/ckanext/ontario_theme/templates/snippets/search_form.html
@@ -1,14 +1,20 @@
 {% ckan_extends %}
 
 {% block search_facets %}
-  {% if query or facets %}
-    <p class="filter-list">  
+  {% if facets %}
+    <p class="filter-list">
     {% if query %}
+      {#
+        Groups/Organizations don't have facets set or the
+        remove_field() function in their index() action. 
+        Only show when facets and a query are available to avoid
+        missing attribute error.
+      #}
       <span>
         <span class="facet">with the keyword(s):</span>
         <span class="filtered pill">
-          {{query}}
-          <a href="{{ c.remove_field('q', query) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+          {{ query }}
+          <a href="{{ facets.remove_field('q', query) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
         </span>
       </span>
     {% endif %}  
@@ -33,9 +39,9 @@
             </span>
           {% endfor %}
           </span>
-        {% endfor %}    
+        {% endfor %}
     {% endif %}
-    </p>     
-    <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>   
+    </p>
+    <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Rework logic to avoid calling `remove_field()`
when it doesn't exist.

Trying to access the `remove_field()` function
when displaying search results for organizations
and groups caused a missing attribute error. This
does not exist in the controller and facets are not setup
for these models in the templates.

References:

- [groups.index](https://github.com/ckan/ckan/blob/717811526bfb25e2af16ae916e6d0d2a76da7c9a/ckan/controllers/group.py#L140)
- [package.search](https://github.com/ckan/ckan/blob/717811526bfb25e2af16ae916e6d0d2a76da7c9a/ckan/controllers/package.py#L134) 
- [package.search.html](https://github.com/ckan/ckan/blob/717811526bfb25e2af16ae916e6d0d2a76da7c9a/ckan/templates/package/search.html#L21)
- [group.index.html](https://github.com/ckan/ckan/blob/2.8/ckan/templates/group/index.html)