### PR TITLE
Remove group

### DIFF
--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
+  {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
+  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -2,6 +2,5 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
 {% endblock %}


### PR DESCRIPTION
We are not currently using groups and have hidden them elsewhere from users that are not logged in. For the time being hide groups from dataset page tab list.