### PR TITLE
Resource size

### DIFF
--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block resource_item_title %}
+<a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
+  {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
+  {{ h.popular('views', res.tracking_summary.total, min=10) }}
+</a>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -2,7 +2,7 @@
 
 {% block resource_item_title %}
 <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
-  {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
+  {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> <span class="text-muted small"> ({{ res.size or _('unknown') }} KB)</span>
   {{ h.popular('views', res.tracking_summary.total, min=10) }}
 </a>
 {% endblock %}


### PR DESCRIPTION
Display resource size if available.

Currently the resource sub-page is handled by scheming and that's implemented separately for now in it's own extension.