### PR TITLE
Distinguish datasets with resource

### DIFF
--- a/ckanext/ontario_theme/templates/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/snippets/package_item.html
@@ -13,6 +13,10 @@
             <li>
               Data includes: <span class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</span>
             </li>
+          {% else %}
+            <li>
+              Data includes: <span class="label label-default" data-format="unknown">external link</span>
+            </li>
           {% endfor %}
         {% endblock %}
       </ul>

--- a/ckanext/ontario_theme/templates/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/snippets/package_item.html
@@ -8,14 +8,15 @@
   {% if package.resources and not hide_resources %}
     {% block resources_outer %}
       <ul class="dataset-resources list-unstyled">
+        Resource formats: 
         {% block resources_inner %}
           {% for resource in h.dict_list_reduce(package.resources, 'format') %}
             <li>
-              Data includes: <span class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</span>
+              <span class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</span>
             </li>
           {% else %}
             <li>
-              Data includes: <span class="label label-default" data-format="unknown">external link</span>
+              <span class="label label-default" data-format="other">other</span>
             </li>
           {% endfor %}
         {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/snippets/package_item.html
@@ -4,10 +4,26 @@
 
 {% ckan_extends %}
 
-{% block resources_inner %}
-  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
-  <li>
-    <span class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</span>
-  </li>
-  {% endfor %}
+{% block resources %}
+  {% if package.resources and not hide_resources %}
+    {% block resources_outer %}
+      <ul class="dataset-resources list-unstyled">
+        {% block resources_inner %}
+          {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+            <li>
+              Data includes: <span class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</span>
+            </li>
+          {% endfor %}
+        {% endblock %}
+      </ul>
+    {% endblock %}
+  {% else %}
+    {% if h.check_access('resource_create', {'package_id': package['id']}) %}
+      {% trans url=h.url_for('resource.new', id=package.name) %}
+        <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+      {% endtrans %}
+    {% else %}
+      <p class="empty">{{ _('This dataset has no data') }}</p>
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/snippets/package_item.html
@@ -24,7 +24,7 @@
     {% endblock %}
   {% else %}
     {% if h.check_access('resource_create', {'package_id': package['id']}) %}
-      {% trans url=h.url_for('resource.new', id=package.name) %}
+      {% trans url=h.url_for(controller='package', action='new_resource', id=package.name) %}
         <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
       {% endtrans %}
     {% else %}


### PR DESCRIPTION
Users were assuming all datasets have data (resources). This PR adds a distinction on the dataset search results page to help indicate what has a resource and what doesn't.

"Resource formats" wording aligns with canadian federal data catalogue. "This dataset has no data" wording comes from dataset template when a dataset does not have a resource.