### PR TITLE
Resource menu change

### DIFF
--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -27,7 +27,7 @@
             {{ _('Download') }}
           {% else %}
             <i class="fa fa-external-link"></i>
-            {{ _('Go to resource') }}
+            {{ _('Open') }}
           {% endif %}
         </a>
       </li>

--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -6,3 +6,38 @@
   {{ h.popular('views', res.tracking_summary.total, min=10) }}
 </a>
 {% endblock %}
+
+{% block resource_item_explore_links %}
+      <li>
+        <a href="{{ url }}">
+          {% if res.has_views %}
+            <i class="fa fa-bar-chart-o"></i>
+            {{ _('Preview') }}
+          {% else %}
+            <i class="fa fa-info-circle"></i>
+            {{ _('More information') }}
+          {% endif %}
+        </a>
+      </li>
+      {% if res.url and h.is_url(res.url) %}
+      <li>
+        <a href="{{ res.url }}" class="resource-url-analytics" target="_blank">
+          {% if res.has_views or res.url_type == 'upload' %}
+            <i class="fa fa-arrow-circle-o-down"></i>
+            {{ _('Download') }}
+          {% else %}
+            <i class="fa fa-external-link"></i>
+            {{ _('Go to resource') }}
+          {% endif %}
+        </a>
+      </li>
+      {% endif %}
+      {% if can_edit %}
+      <li>
+        <a href="{{ h.url_for('resource.edit', id=pkg.name, resource_id=res.id) }}">
+          <i class="fa fa-pencil-square-o"></i>
+          {{ _('Edit') }}
+        </a>
+      </li>
+      {% endif %}
+      {% endblock %}

--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -15,7 +15,7 @@
             {{ _('Preview') }}
           {% else %}
             <i class="fa fa-info-circle"></i>
-            {{ _('More information') }}
+            {{ _('About') }}
           {% endif %}
         </a>
       </li>


### PR DESCRIPTION
Small change to resource menu under "explore" to change:
- "go to resource" to "open"
- "more information" to "about"

Addresses the following ticket: https://trello.com/c/8lJKv19T/354-people-dont-know-what-more-information-and-go-to-resource-will-do
This was done to address confusion in initial usability studies. More common language is proposed.