### PR TITLE
Ui adjustments

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -388,6 +388,13 @@ body,
     background-color: transparent;
   }
 }
+#dataset-search-form {
+  margin: 0px 0px 20px 0px;
+  background: #fafafa;
+  padding: 20px;
+  border-radius: 5px;
+  border: none;
+}
 .hero {
   background-image: none;
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url(/images/backgrounds/richard-balog-647377-unsplash_converted.jpg);

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -97,6 +97,14 @@ body,
   }
 }
 
+#dataset-search-form {
+  margin: 0px 0px 20px 0px;
+  background: #fafafa;
+  padding: 20px;
+  border-radius: 5px;
+  border: none;
+}
+
 .hero {
   background-image: none;
   background: linear-gradient(0deg,rgba(0,0,0,.3),rgba(0,0,0,0.3)), url(/images/backgrounds/richard-balog-647377-unsplash_converted.jpg);

--- a/ckanext/ontario_theme/templates/header.html
+++ b/ckanext/ontario_theme/templates/header.html
@@ -71,7 +71,7 @@
   <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
     {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities)
     %}
-    <a href="{{ h.url_for('dashboard.index') }}" title="{{ notifications_tooltip }}">
+    <a href="{{ h.url_for('dashboard.datasets') }}" title="{{ notifications_tooltip }}">
       <i class="fa fa-tachometer" aria-hidden="true"></i>
       <span class="text">{{ _('Dashboard') }}</span>
       <span class="badge">{{ new_activities }}</span>

--- a/ckanext/ontario_theme/templates/header.html
+++ b/ckanext/ontario_theme/templates/header.html
@@ -52,3 +52,44 @@
     </div>
   </form>
 {% endblock %}
+
+{% block header_account_logged %} {% if c.userobj.sysadmin %}
+  <li>
+    <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+      <i class="fa fa-gavel" aria-hidden="true"></i>
+      <span class="text">{{ _('Admin') }}</span>
+    </a>
+  </li>
+  {% endif %}
+  <li>
+    <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
+            {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
+            <span class="username">{{ c.userobj.display_name }}</span>
+          </a>
+  </li>
+  {% set new_activities = h.new_activities() %}
+  <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
+    {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities)
+    %}
+    <a href="{{ h.url_for('dashboard.index') }}" title="{{ notifications_tooltip }}">
+      <i class="fa fa-tachometer" aria-hidden="true"></i>
+      <span class="text">{{ _('Dashboard') }}</span>
+      <span class="badge">{{ new_activities }}</span>
+    </a>
+  </li>
+  {% block header_account_settings_link %}
+  <li>
+    <a href="{{ h.url_for('user.edit', id=c.userobj.name) }}" title="{{ _('Edit settings') }}">
+      <i class="fa fa-cog" aria-hidden="true"></i>
+      <span class="text">{{ _('Settings') }}</span>
+    </a>
+  </li>
+  {% endblock %} {% block header_account_log_out_link %}
+  <li>
+    <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
+      <i class="fa fa-sign-out" aria-hidden="true"></i>
+      <span class="text">{{ _('Log out') }}</span>
+    </a>
+  </li>
+  {% endblock %} 
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -4,3 +4,9 @@
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
 {% endblock %}
+
+{% block content_action %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -7,6 +7,6 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}
+    {% link_for _('Edit'), controller='package', action='edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/package/snippets/package_form.html
+++ b/ckanext/ontario_theme/templates/package/snippets/package_form.html
@@ -1,3 +1,3 @@
 {% ckan_extends %}
 
-{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}
+{% block save_button_text %}{{ _('Save and Add Data') }}{% endblock %}

--- a/ckanext/ontario_theme/templates/package/snippets/package_form.html
+++ b/ckanext/ontario_theme/templates/package/snippets/package_form.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+
+{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}

--- a/ckanext/ontario_theme/templates/user/dashboard.html
+++ b/ckanext/ontario_theme/templates/user/dashboard.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block page_header %}
+  <header class="module-content page-header hug">
+    <div class="content_action">
+      {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+    </div>
+    <ul class="nav nav-tabs">
+      {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
+      {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
+      {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
+      {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}
+    </ul>
+  </header>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/user/dashboard.html
+++ b/ckanext/ontario_theme/templates/user/dashboard.html
@@ -6,8 +6,8 @@
       {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
     </div>
     <ul class="nav nav-tabs">
-      {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
       {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
+      {{ h.build_nav_icon('dashboard.index', _('News feed')) }}      
       {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
       {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}
     </ul>


### PR DESCRIPTION
This consists of a few small cosmetic changes to Colby as a result of confusion in initial user testing. These changes include:
- having user datasets (and not news feed) as the default view for the user dashboard
- harmonizing the look of the search bar in the datasets search page with the left side filtering options (matching with the grey of the left side filtering options)
- Change the "Manage" button for datasets to the more commonly used "Edit" and apply colour so it doesn't blend in so much with the background
- change the "next: add data" to "save and add data" in the "new datasets" page to make it clear that your meta data entered so far will be saved