### PR TITLE
Improvement: Restored groups link in the show package page

### DIFF
--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -1,10 +1,5 @@
 {% ckan_extends %}
 
-{% block content_primary_nav %}
-  {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
-{% endblock %}
-
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
     {% link_for _('Edit'), controller='package', action='edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}


### PR DESCRIPTION
This has one simple change: restoring the link to groups for a package in the show package page. It was originally removed because we weren't using groups, but they've been proven to be quite useful.