### PR TITLE
Bug: OG staff leads link doesn't work anymore

### DIFF
--- a/ckanext/ontario_theme/templates/organization/snippets/helper.html
+++ b/ckanext/ontario_theme/templates/organization/snippets/helper.html
@@ -18,13 +18,13 @@ Renders the general organization description/definition.
           Questions
         </h3>
         <p>
-          For questions about ministry data and records, contact the ministry’s <a href="https://intra.sdc.gov.on.ca/sites/cac-oak/collab/opengovteam/OGLeads/Lists/Staff%20Leads/Staff%20Leads.aspx">open government lead</a>.
+          For questions about ministry data and records, contact the ministry’s <a href="/dataset/open-government-staff-leads">open government lead</a>.
         </p>
         <h3>
           Managing Ministry Data
         </h3>
         <p>
-          Ministries can only manage their own data and records. If you’re having trouble with your account or permissions, contact your ministry's <a href="https://intra.sdc.gov.on.ca/sites/cac-oak/collab/opengovteam/OGLeads/Lists/Staff%20Leads/Staff%20Leads.aspx">open government lead</a>.
+          Ministries can only manage their own data and records. If you’re having trouble with your account or permissions, contact your ministry's <a href="/dataset/open-government-staff-leads">open government lead</a>.
         </p>
         <!--h3>
           Keeping up-to-date


### PR DESCRIPTION
The link to og leads in the organizations index page was broken because we're not using sharepoint anymore. The link was updated to the new og leads colby dataset.