### PR TITLE
Harmonize search bar look

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -496,7 +496,8 @@ table.table tbody tr td {
 .media-grid {
   border: none;
 }
-.page_primary_action .add-dataset {
+.page_primary_action .add-dataset,
+.page_primary_action .add-organization {
   text-align: right;
 }
 /* =====================================================

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -400,7 +400,8 @@ body,
     background-color: transparent;
   }
 }
-#dataset-search-form {
+#dataset-search-form,
+#organization-search-form {
   margin: 0px 0px 20px 0px;
   background: #fafafa;
   padding: 20px;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -287,6 +287,18 @@ a.card:hover {
 .label[data-format*=turtle] {
   background-color: #0b4498;
 }
+.format-label[data-format=kml],
+.format-label[data-format*=kml] {
+  width: 31px;
+  height: 35px;
+  background-position: -383px -62px;
+}
+.format-label[data-format=shp],
+.format-label[data-format*=shp] {
+  width: 31px;
+  height: 35px;
+  background-position: -414px -62px;
+}
 .stats .number {
   display: block;
   font-size: 60px;
@@ -483,6 +495,9 @@ table.table tbody tr td {
 }
 .media-grid {
   border: none;
+}
+.page_primary_action .add-dataset {
+  text-align: right;
 }
 /* =====================================================
    Sub page left panel border removal

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -204,6 +204,10 @@ table.table {
   border: none;
 }
 
+.page_primary_action .add-dataset {
+  text-align: right; 
+}
+
 /* =====================================================
    Sub page left panel border removal
    ===================================================== */

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -97,7 +97,7 @@ body,
   }
 }
 
-#dataset-search-form {
+#dataset-search-form, #organization-search-form {
   margin: 0px 0px 20px 0px;
   background: #fafafa;
   padding: 20px;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -204,7 +204,7 @@ table.table {
   border: none;
 }
 
-.page_primary_action .add-dataset {
+.page_primary_action .add-dataset, .page_primary_action .add-organization {
   text-align: right; 
 }
 

--- a/ckanext/ontario_theme/templates/organization/index.html
+++ b/ckanext/ontario_theme/templates/organization/index.html
@@ -1,18 +1,22 @@
 {% ckan_extends %}
 
 {% block page_primary_action %}
-  <div class="add-organization">
-  {% if h.check_access('organization_create') %}
-    {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
-  {% endif %}
-  </div>
 {% endblock %}
 
-{% block primary_content_inner %}
+{% block pre_primary %}
+  <div class="page_primary_action">
+    <div class="add-organization">
+    {% if h.check_access('organization_create') %}
+      {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
+    {% endif %}
+    </div>
+  </div>
   <h1 class="hide-heading">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
   {% block organizations_search_form %}
     {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
   {% endblock %}
+{% endblock %}
+{% block primary_content_inner %}
   {% block organizations_list %}
     {% if c.page.items or request.params %}
       {% if c.page.items %}

--- a/ckanext/ontario_theme/templates/organization/index.html
+++ b/ckanext/ontario_theme/templates/organization/index.html
@@ -1,7 +1,9 @@
 {% ckan_extends %}
 
 {% block page_primary_action %}
+  <div class="add-organization">
   {% if h.check_access('organization_create') %}
     {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
   {% endif %}
+  </div>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/organization/index.html
+++ b/ckanext/ontario_theme/templates/organization/index.html
@@ -7,3 +7,27 @@
   {% endif %}
   </div>
 {% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
+  {% block organizations_search_form %}
+    {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+  {% endblock %}
+  {% block organizations_list %}
+    {% if c.page.items or request.params %}
+      {% if c.page.items %}
+        {% snippet "organization/snippets/organization_list.html", organizations=c.page.items %}
+      {% endif %}
+    {% else %}
+      <p class="empty">
+        {{ _('There are currently no organizations for this site') }}.
+        {% if h.check_access('organization_create') %}
+          {% link_for _('How about creating one?'), controller='organization', action='new' %}</a>.
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endblock %}
+  {% block page_pagination %}
+    {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
+  {% endblock %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/organization/index.html
+++ b/ckanext/ontario_theme/templates/organization/index.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block page_primary_action %}
+  {% if h.check_access('organization_create') %}
+    {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/add_dataset.html
+++ b/ckanext/ontario_theme/templates/snippets/add_dataset.html
@@ -1,0 +1,10 @@
+{# Adds 'Add Dataset' button #}
+
+{% set dataset_type = dataset_type if dataset_type else 'dataset' %}
+<div class="add-dataset">
+{% if group %}
+    {% link_for _('Add Dataset'), controller='package', action='new', group=group, class_='btn btn-primary', icon='plus-square' %}
+{% else %}
+    {% link_for _('Add ' + dataset_type.title()), controller='package', action='new', named_route=dataset_type + '_new', class_='btn btn-primary', icon='plus-square' %}
+{% endif %}
+</div>


### PR DESCRIPTION
This pull request consists of one commit to address:
https://trello.com/c/QN1a5T9f/385-harmonizing-the-look-of-the-search-bar-in-the-datasets-search-page-with-the-left-side-filtering-options-matching-with-the-grey-o

It changes the organizations search bar to match the packages search bar.