### PR TITLE
Improvement: Language toggle link added in header for english and french

### DIFF
--- a/ckanext/ontario_theme/templates/header.html
+++ b/ckanext/ontario_theme/templates/header.html
@@ -91,5 +91,16 @@
       <span class="text">{{ _('Log out') }}</span>
     </a>
   </li>
+  {% endblock %} {% block header_language_toggle_link %}
+  <li>
+    {% set current_lang = request.environ.CKAN_LANG %}
+    {% set toggle_to = "fr" %} 
+    {% if current_lang == "fr" %}
+    {% set toggle_to = "en" %} 
+    {% endif %}
+    <a href="{{ h.url_for(h.current_url(), locale=toggle_to) }}" title="{{ toggle_to }}">
+      {{toggle_to|upper}}
+    </a>
+  </li>
   {% endblock %} 
 {% endblock %}


### PR DESCRIPTION
This pull request has one major change to address:
https://trello.com/c/yoZPZRE8/388-language-selector-missing-from-site

A EN/FR toggle was added to the header. 