### PR TITLE
Change go to resource to open globally

### DIFF
--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -13,7 +13,7 @@
       {% elif  res.resource_type == 'api' %}
         <i class="fa fa-key"></i> {{ _('API Endpoint') }}
       {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
-        <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+        <i class="fa fa-external-link"></i> {{ _('Open') }}
       {% else %}
         <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
       {% endif %}

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -1,0 +1,42 @@
+{% ckan_extends %}
+
+{% block resource_actions_inner %}
+{% if h.check_access('package_update', {'id':pkg.id }) %}
+  <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+{% endif %}
+{% if res.url and h.is_url(res.url) %}
+  <li>
+    <div class="btn-group">
+    <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+      {% if res.resource_type in ('listing', 'service') %}
+        <i class="fa fa-eye"></i> {{ _('View') }}
+      {% elif  res.resource_type == 'api' %}
+        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+      {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
+        <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+      {% else %}
+        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+      {% endif %}
+    </a>
+     {% block download_resource_button %}
+      {%if res.datastore_active %}
+    <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+        <span class="caret"></span>
+      </button>
+    <ul class="dropdown-menu">
+      <li>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
+          target="_blank"><span>CSV</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
+          target="_blank"><span>TSV</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
+          target="_blank"><span>JSON</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
+          target="_blank"><span>XML</span></a>
+      </li>
+    </ul>
+    {%endif%} {% endblock %}
+    </div>
+  </li>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
This pull request has one change to address:
https://trello.com/c/VslFl3IJ/396-look-at-changing-all-instances-go-to-resource-to-open-to-be-consistent-with-pr-35

Any instance of "go to resource" across the codebase was changed to "open".

