### PR TITLE
Change manage to edit globally

### DIFF
--- a/ckanext/ontario_theme/templates/group/edit.html
+++ b/ckanext/ontario_theme/templates/group/edit.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content_inner %}
+  <li>{% link_for group.display_name|truncate(35), controller='group', action='read', id=group.name %}</li>
+  <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name %}</li>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/group/edit.html
+++ b/ckanext/ontario_theme/templates/group/edit.html
@@ -2,5 +2,5 @@
 
 {% block breadcrumb_content_inner %}
   <li>{% link_for group.display_name|truncate(35), controller='group', action='read', id=group.name %}</li>
-  <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name %}</li>
+  <li class="active">{% link_for _('Edit'), controller='group', action='edit', id=group.name %}</li>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/group/edit_base.html
+++ b/ckanext/ontario_theme/templates/group/edit_base.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content_inner %}
   <li>{% link_for group.display_name|truncate(35), controller='group', action='read', id=group.name, named_route=group_type + '_read' %}</li>
-  <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name, named_route=group_type + '_edit' %}</li>
+  <li class="active">{% link_for _('Edit'), controller='group', action='edit', id=group.name, named_route=group_type + '_edit' %}</li>
 {% endblock %}
 
 

--- a/ckanext/ontario_theme/templates/group/edit_base.html
+++ b/ckanext/ontario_theme/templates/group/edit_base.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content_inner %}
+  <li>{% link_for group.display_name|truncate(35), controller='group', action='read', id=group.name, named_route=group_type + '_read' %}</li>
+  <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name, named_route=group_type + '_edit' %}</li>
+{% endblock %}
+
+

--- a/ckanext/ontario_theme/templates/group/read_base.html
+++ b/ckanext/ontario_theme/templates/group/read_base.html
@@ -2,6 +2,6 @@
 
 {% block content_action %}
   {% if h.check_access('group_update', {'id': c.group_dict.id}) %}
-    {% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn btn-default', icon='wrench', named_route=group_type + '_edit' %}
+    {% link_for _('Edit'), controller='group', action='edit', id=c.group_dict.name, class_='btn btn-secondary', icon='wrench', named_route=group_type + '_edit' %}
   {% endif %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/group/read_base.html
+++ b/ckanext/ontario_theme/templates/group/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_action %}
+  {% if h.check_access('group_update', {'id': c.group_dict.id}) %}
+    {% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn btn-default', icon='wrench', named_route=group_type + '_edit' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/organization/edit_base.html
+++ b/ckanext/ontario_theme/templates/organization/edit_base.html
@@ -2,5 +2,5 @@
 
 {% block breadcrumb_content_inner %}
     <li>{% link_for organization.display_name|truncate(35), controller='organization', action='read', id=organization.name, named_route=group_type + '_read' %}</li>
-    <li class="active">{% link_for _('Manage'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
+    <li class="active">{% link_for _('Edit'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/organization/edit_base.html
+++ b/ckanext/ontario_theme/templates/organization/edit_base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content_inner %}
+    <li>{% link_for organization.display_name|truncate(35), controller='organization', action='read', id=organization.name, named_route=group_type + '_read' %}</li>
+    <li class="active">{% link_for _('Manage'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/organization/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_action %}
+  {% if h.check_access('organization_update', {'id': c.group_dict.id}) %}
+    {% link_for _('Manage'), controller='organization', action='edit', id=c.group_dict.name, class_='btn btn-default', icon='wrench', named_route=group_type + '_edit'  %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/organization/read_base.html
@@ -2,6 +2,6 @@
 
 {% block content_action %}
   {% if h.check_access('organization_update', {'id': c.group_dict.id}) %}
-    {% link_for _('Manage'), controller='organization', action='edit', id=c.group_dict.name, class_='btn btn-default', icon='wrench', named_route=group_type + '_edit'  %}
+    {% link_for _('Edit'), controller='organization', action='edit', id=c.group_dict.name, class_='btn btn-secondary', icon='wrench', named_route=group_type + '_edit'  %}
   {% endif %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -1,0 +1,43 @@
+{% ckan_extends %}
+
+{% block resource_actions_inner %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    <li>{% link_for _('Manage'), named_route='resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+  {% endif %}
+  {% if res.url and h.is_url(res.url) %}
+    <li>
+      <div class="btn-group">
+      <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+        {% if res.resource_type in ('listing', 'service') %}
+          <i class="fa fa-eye"></i> {{ _('View') }}
+        {% elif  res.resource_type == 'api' %}
+          <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+        {% elif not res.has_views and not res.url_type == 'upload' %}
+          <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+        {% else %}
+          <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+        {% endif %}
+      </a>
+       {% block download_resource_button %}
+        {%if res.datastore_active %}
+      <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+          <span class="caret"></span>
+        </button>
+      <ul class="dropdown-menu">
+        <li>
+          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
+            target="_blank"><span>CSV</span></a>
+          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
+            target="_blank"><span>TSV</span></a>
+          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
+            target="_blank"><span>JSON</span></a>
+          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
+            target="_blank"><span>XML</span></a>
+        </li>
+      </ul>
+      {%endif%} {% endblock %}
+      </div>
+    </li>
+  {% endif %}
+ {% endblock %}
+

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -2,7 +2,7 @@
 
 {% block resource_actions_inner %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    <li>{% link_for _('Manage'), named_route='resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+    <li>{% link_for _('Edit'), named_route='resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='wrench' %}</li>
   {% endif %}
   {% if res.url and h.is_url(res.url) %}
     <li>

--- a/ckanext/ontario_theme/templates/user/edit.html
+++ b/ckanext/ontario_theme/templates/user/edit.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content %}
+  <li><a href="{{ h.url_for('user.index') }}">{{ _('Users') }}</a></li>
+  <li><a href="{{ h.url_for('user.read', id=user_dict.name) }}">{{ user_dict.display_name }}</a></li>
+  <li class="active"><a href="#">{{ _('Manage') }}</a></li>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/user/edit.html
+++ b/ckanext/ontario_theme/templates/user/edit.html
@@ -3,5 +3,5 @@
 {% block breadcrumb_content %}
   <li><a href="{{ h.url_for('user.index') }}">{{ _('Users') }}</a></li>
   <li><a href="{{ h.url_for('user.read', id=user_dict.name) }}">{{ user_dict.display_name }}</a></li>
-  <li class="active"><a href="#">{{ _('Manage') }}</a></li>
+  <li class="active"><a href="#">{{ _('Edit') }}</a></li>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/user/edit_base.html
+++ b/ckanext/ontario_theme/templates/user/edit_base.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+
+{% block subtitle %}{{ _('Manage') }} - {{ user_dict.display_name }} - {{ _('Users') }}{% endblock %}

--- a/ckanext/ontario_theme/templates/user/edit_base.html
+++ b/ckanext/ontario_theme/templates/user/edit_base.html
@@ -1,3 +1,3 @@
 {% ckan_extends %}
 
-{% block subtitle %}{{ _('Manage') }} - {{ user_dict.display_name }} - {{ _('Users') }}{% endblock %}
+{% block subtitle %}{{ _('Edit') }} - {{ user_dict.display_name }} - {{ _('Users') }}{% endblock %}

--- a/ckanext/ontario_theme/templates/user/read_base.html
+++ b/ckanext/ontario_theme/templates/user/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_action %}
+  {% if h.check_access('user_update', user) %}
+    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='wrench' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/user/read_base.html
+++ b/ckanext/ontario_theme/templates/user/read_base.html
@@ -2,6 +2,6 @@
 
 {% block content_action %}
   {% if h.check_access('user_update', user) %}
-    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Edit'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request consists of one overarching change to change "manage" to "edit" globally within the codebase. It resolves this ticket:

https://trello.com/c/ihVJdKJy/279-change-manage-button-on-dataset-to-say-edit-instead-for-all-instances