### PR TITLE
Bug: Fix css that should only apply to dataset details table, but was…

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -478,7 +478,7 @@ table.table tbody tr th,
 table.table tbody tr td {
   border: none;
 }
-table.table tbody tr td {
+table.table tbody tr td.dataset-details {
   width: 75%;
 }
 .media-grid {

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -195,7 +195,7 @@ table.table {
   tbody tr th, tbody tr td {
     border: none;
   }
-  tbody tr td {
+  tbody tr td.dataset-details {
     width: 75%;
   }
 }


### PR DESCRIPTION
Bug: Fix css that should only apply to dataset details table, but was applied to all tables

This pull request consists of one commit and one change:
- a css rule for table cells was made more specific to only apply to dataset detail table cells