### PR TITLE
Bug: Resource item edit link gave 404.

### DIFF
--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -37,7 +37,7 @@
         </a>
       {% endif %}
       {% if can_edit %}
-        <a href="{{ h.url_for('resource.edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
+        <a href="{{ h.url_for(controller='package', action='resource_edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
           <i class="fa fa-pencil-square-o"></i>
           {{ _('Edit') }}
         </a>


### PR DESCRIPTION
This is due to using ckan master template as the base
instead of the ckan version we're using (2.8.2). Some
routes are using flask and others are using pylons and
each version more flask views are introduced that replace
the old controllers but this breaks if the migration hasn't
happened yet for a controller.

Introduced in PR #35 