### PR TITLE
Task: Switch language toggle from EN/FR to english/français

### DIFF
--- a/ckanext/ontario_theme/templates/snippets/ontario_theme_language_selector.html
+++ b/ckanext/ontario_theme/templates/snippets/ontario_theme_language_selector.html
@@ -9,5 +9,5 @@
   {% set toggle_to = "en" %}
 {% endif %}
 <a href="{{ h.url_for(h.current_url(), locale=toggle_to) }}" title="{{ toggle_to }}">
-  {{toggle_to|upper}}
+  {{'français' if current_lang =='en' else 'english'}}
 </a>


### PR DESCRIPTION
Originally the toggle used "en" and "fr" for labels. But Ontario.ca uses "english" and "français". This pull request consists of one commit to change those labels.