### PR TITLE
Internal external data distinction

### DIFF
--- a/ckanext/ontario_theme/fanstatic/labels.less
+++ b/ckanext/ontario_theme/fanstatic/labels.less
@@ -59,3 +59,19 @@
 .label[data-format*=turtle] {
   background-color: #0b4498;
 }
+
+.label.label-open {
+  color: rgb(100,100,100);
+  border: solid 1px #006B3F;
+  border-left: solid 5px #006B3F;
+}
+
+.label.label-colby {
+  color: rgb(100,100,100);
+  border: solid 1px #D47500;
+  border-left: solid 5px #D47500;
+}
+
+.label.float-right {
+  float: right;
+}

--- a/ckanext/ontario_theme/fanstatic/labels.less
+++ b/ckanext/ontario_theme/fanstatic/labels.less
@@ -75,3 +75,9 @@
 .label.float-right {
   float: right;
 }
+
+h1 .label.label-colby, h1 .label.label-open {
+  font-size: 40%;
+  border-width: 2px;
+  border-left-width: 10px;
+}

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -300,6 +300,12 @@ a.card:hover {
 .label.float-right {
   float: right;
 }
+h1 .label.label-colby,
+h1 .label.label-open {
+  font-size: 40%;
+  border-width: 2px;
+  border-left-width: 10px;
+}
 .stats .number {
   display: block;
   font-size: 60px;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -287,6 +287,19 @@ a.card:hover {
 .label[data-format*=turtle] {
   background-color: #0b4498;
 }
+.label.label-open {
+  color: #646464;
+  border: solid 1px #006B3F;
+  border-left: solid 5px #006B3F;
+}
+.label.label-colby {
+  color: #646464;
+  border: solid 1px #D47500;
+  border-left: solid 5px #D47500;
+}
+.label.float-right {
+  float: right;
+}
 .stats .number {
   display: block;
   font-size: 60px;
@@ -312,6 +325,7 @@ a.card:hover {
   width: 18rem;
   height: 18rem;
 }
+
 /* =====================================================
    Typography
    ===================================================== */

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -331,7 +331,6 @@ h1 .label.label-open {
   width: 18rem;
   height: 18rem;
 }
-
 /* =====================================================
    Typography
    ===================================================== */
@@ -340,6 +339,9 @@ body {
 }
 h1 {
   font-size: 35px;
+}
+.module h1 {
+  margin-bottom: 0px;
 }
 h2 {
   font-size: 25px;
@@ -503,6 +505,13 @@ table.table tbody tr td {
 }
 .media-grid {
   border: none;
+}
+.catalogue-source {
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #555;
 }
 /* =====================================================
    Sub page left panel border removal

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -19,6 +19,10 @@ h1 {
   font-size: 35px;
 }
 
+.module h1 {
+  margin-bottom: 0px;
+}
+
 h2 {
   font-size: 25px;
 } 
@@ -203,6 +207,16 @@ table.table {
 .media-grid {
   border: none;
 }
+
+.catalogue-source {
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #555;
+}
+
+
 
 /* =====================================================
    Sub page left panel border removal

--- a/ckanext/ontario_theme/templates/package/read.html
+++ b/ckanext/ontario_theme/templates/package/read.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block page_heading %}
+  {{ h.dataset_display_name(pkg) }}
+  {% if pkg.state.startswith('draft') %}
+    [{{ _('Draft') }}]
+  {% endif %}
+  {% if pkg.state == 'deleted' %}
+    [{{ _('Deleted') }}]
+  {% endif %}
+  {% if pkg.get('node_id', '') != "" %}
+    <span class="label label-open float-right">{{ _('Open') }}</span>
+  {% else %}
+    <span class="label label-colby float-right">{{ _('Colby') }}</span>
+  {% endif %}  
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read.html
+++ b/ckanext/ontario_theme/templates/package/read.html
@@ -1,16 +1,15 @@
 {% ckan_extends %}
 
-{% block page_heading %}
-  {{ h.dataset_display_name(pkg) }}
-  {% if pkg.state.startswith('draft') %}
-    [{{ _('Draft') }}]
-  {% endif %}
-  {% if pkg.state == 'deleted' %}
-    [{{ _('Deleted') }}]
-  {% endif %}
+{% block package_notes %}
+  <div class="catalogue-source">
   {% if pkg.get('node_id', '') != "" %}
-    <span class="label label-open float-right">{{ _('Open') }}</span>
+    <span class="label label-open">{{ _('Open') }}</span>
+    _('This data asset is available to the public through the public data catalogue.')
   {% else %}
-    <span class="label label-colby float-right">{{ _('Colby') }}</span>
-  {% endif %}  
+    <span class="label label-colby">{{ _('Colby') }}</span>
+    _('This data asset is only documented internally in the Ontario Public Service (on Colby).')
+  {% endif %} 
+  </div>
+
+  {{ super() }}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/package_item.html
+++ b/ckanext/ontario_theme/templates/snippets/package_item.html
@@ -4,6 +4,20 @@
 
 {% ckan_extends %}
 
+{% block heading_meta %}
+  {% if package.get('state', '').startswith('draft') %}
+    <span class="label label-info">{{ _('Draft') }}</span>
+  {% elif package.get('state', '').startswith('deleted') %}
+    <span class="label label-danger">{{ _('Deleted') }}</span>
+  {% endif %}
+  {% if package.get('node_id', '') != "" %}
+    <span class="label label-open float-right">{{ _('Open') }}</span>
+  {% else %}
+    <span class="label label-colby float-right">{{ _('Colby') }}</span>
+  {% endif %}
+  {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+{% endblock %}
+
 {% block resources %}
   {% if package.resources and not hide_resources %}
     {% block resources_outer %}


### PR DESCRIPTION
This pull request adds a label differentiating between open/colby to each package in 2 views: package read and search packages. This pull request will only show the changes in the search packages view. In order to fully see these changes (the change on the package read page), the corresponding pull request in the extrafields codebase must also be applied. The pull request consists of 3 commits.