### PR TITLE
Odc beta layout

### DIFF
--- a/ckanext/ontario_theme/templates/home/snippets/ontario_theme_contact_us.html
+++ b/ckanext/ontario_theme/templates/home/snippets/ontario_theme_contact_us.html
@@ -7,34 +7,8 @@ Renders contact information for the site on the home page.
   <h2>Contact us</h2>
 
     <div class="row">
-      <div class="col-md-6">
-        <h3><a href="https://mailchi.mp/43387219d995/openonnewsletter">Subscribe</a></h3>
-        <p>
-          Subscribe to our mailing list to find out what’s new in the world of Open Government and what new data and records have been added to Colby. Or check us out on <a href="https://twitter.com/opengovon">Twitter</a>.
-        </p>
-      </div>
-      <div class="col-md-6">
-        <h3>Data enquiries</h3>
-        <p>For feedback and questions on individual datasets or records contact the maintainer (listed on the dataset page) by email.</p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-6">
-         <h3><a href="/dataset/open-government-staff-leads">Ministry contacts</a></h3>
-         <p>Contact your ministry’s open government lead with questions you have about open data, open information and public consultations.</p>
-       </div>
-      <div class="col-md-6">
-         <h3>Colby team</h3>
-         <p>If you have questions about the Colby site, email <a href="mailto:opengov@ontario.ca">opengov@ontario.ca</a></p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-6">
-         <h3><a href="https://intra.sdc.gov.on.ca/sites/cac-oak/collab/opengovteam/OGLeads/SitePages/OG%20Support%20Teams.aspx">Open government advisors</a></h3>
-         <p>If you are a ministry open government lead, contact your open government advisor for questions about open data, open information and public consultations.</p>
-      </div>
+      <div class="col-md-12">
+       
     </div>
 
 </div>

--- a/ckanext/ontario_theme/templates/home/snippets/ontario_theme_contact_us.html
+++ b/ckanext/ontario_theme/templates/home/snippets/ontario_theme_contact_us.html
@@ -9,6 +9,6 @@ Renders contact information for the site on the home page.
     <div class="row">
       <div class="col-md-12">
        
+      </div>
     </div>
-
 </div>

--- a/ckanext/ontario_theme/templates/home/snippets/ontario_theme_featured_content.html
+++ b/ckanext/ontario_theme/templates/home/snippets/ontario_theme_featured_content.html
@@ -3,47 +3,42 @@
 Renders a row of 3 featured content cards on the home page.
 
 These are hardcoded values, typically highlighting datasets
-already existing in the system.
+already existing in the system or news about the data catalogue.
 
 #}
 
   <div class="row">
     <div class="col-md-12">
-      <h2>Featured data</h2>
+      <h2>News</h2>
     </div>
   </div>
 
   <div class="row">
     <div class="col-md-4">
-      <a href="/dataset/statscan-census-2016-labour-force-market-data-labour-force-status" class="card">
+      <a href="" class="card">
         <div>
-          <img alt="Photograph of three workers on a construction site."
-          src="/images/featured_content/Workers.png">
-          <h3>Labour Force Market Data</h3>
-          <p>2016 census data from Statistics Canada with population counts that you can filter by location, age, gender, highest certification and more.</p>
+          <h3></h3>
+          <p></p>
         </div>
       </a>
     </div>
 
     <div class="col-md-4">
-      <a href="/dataset/artificial-intelligence-companies-in-ontario" class="card">
+      <a href="" class="card">
         <div>
-          <img alt="Pigs" src="/images/featured_content/featureddata-ai.jpg">
-          <h3>AI Companies in Ontario</h3>
-          <p>A list of Artificial Intelligence companies with headquarter locations in Ontario.</p>
+          <h3></h3>
+          <p></p>
         </div>
       </a>  
     </div>
 
     <div class="col-md-4">
-      <a href="/dataset/serviceontario-services-inventory" class="card">
+      <a href="" class="card">
         <div>
-          <img alt="ServiceOntario employee" src="/images/featured_content/featureddata-serviceontario.jpg">
-          <h3>ServiceOntario</h3>
-          <p>What services are provided, how many people use them, how satisfied people are and more.</p>
+          <h3></h3>
+          <p></p>
         </div>
       </a>
     </div>
   </div>
 
-  <p>Want to see your data featured here on the homepage? Contact us at <a href="mailto:opengov@ontario.ca">opengov@ontario.ca</a></p>

--- a/ckanext/ontario_theme/templates/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/home/snippets/ontario_theme_intro.html
@@ -1,31 +1,11 @@
 {#
 
 Renders a hard coded site description/introduction to
-help users better understand what Colby is and how it
-can be used.
+help users better understand the data catalogue
 
 #}
 <div class="row">
-  <div class="col-md-4">
-    <h2><i class="fa fa-bullhorn large pull-left"></i> Share</h2>
-    <p>Let other ministries explore and learn from your amazing data and information.</p>
-  </div>
-
-  <div class="col-md-4">
-    <h2><i class="fa fa-download large pull-left"></i> Get</h2>
-    <p>Access data other ministries have shared and data from <a href="https://www.ontario.ca/data">Ontario's public catalogue</a>.</p>
-  </div>
-
-  <div class="col-md-4">
-    <h2><i class="fa fa-line-chart large pull-left"></i> Use</h2>
-    <p>Find creative solutions for policy and program design and measurement with data.</p>
-  </div>
-</div>
-
-<div class="row">
   <div class="col-md-12">
-    <p>
-      <a href="/about" class="btn btn-lg btn-primary">Learn more about Colby</a>
-    </p>
+
   </div>
 </div>


### PR DESCRIPTION
This pull request consists of html structure changes for the landing page for the public-facing data catalogue:
- the conversion of the 3 columns under the main search banner to one column
- featured datasets cards changed to remove images
- contact us section changed from two columns and multiple rows to one column/row