### PR TITLE
Task: Add Multi-lingual tag support

### DIFF
--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -6,6 +6,7 @@ from flask import Blueprint, make_response
 from flask import render_template, render_template_string
 
 import ckanapi_exporter.exporter as exporter
+import json
 
 from ckan.model import Package
 
@@ -312,23 +313,21 @@ class OntarioThemePlugin(plugins.SingletonPlugin):
         '''
         facets_dict['access_level'] = toolkit._('Access Level')
         facets_dict['update_frequency'] = toolkit._('Update Frequency')
+        facets_dict['keywords_en'] = toolkit._('Keywords')
+        facets_dict['keywords_fr'] = toolkit._('Keywords')
         return facets_dict
 
     def group_facets(self, facets_dict, group_type, package_type):
         u'''Modify and return the ``facets_dict`` for a group's page.
         Throws AttributeError: no attribute 'organization_facets' without function.
         '''
-        facets_dict['access_level'] = toolkit._('Access Level')
-        facets_dict['update_frequency'] = toolkit._('Update Frequency')
-        return facets_dict
+        return self.dataset_facets(facets_dict, package_type)
 
     def organization_facets(self, facets_dict, organization_type, package_type):
         u'''Modify and return the ``facets_dict`` for an organization's page.
         Throws AttributeError: no attribute 'organization_facets' without function.
         '''
-        facets_dict['access_level'] = toolkit._('Access Level')
-        facets_dict['update_frequency'] = toolkit._('Update Frequency')
-        return facets_dict
+        return self.dataset_facets(facets_dict, package_type)
 
     # IPackageController
 
@@ -342,6 +341,9 @@ class OntarioThemePlugin(plugins.SingletonPlugin):
         return search_results
 
     def before_index(self, pkg_dict):
+        kw = json.loads(pkg_dict.get('extras_keywords', '{}'))
+        pkg_dict['keywords_en'] = kw.get('en', [])
+        pkg_dict['keywords_fr'] = kw.get('fr', [])
         return pkg_dict
 
     def before_view(self, pkg_dict):

--- a/ckanext/ontario_theme/plugin.py
+++ b/ckanext/ontario_theme/plugin.py
@@ -209,6 +209,32 @@ def get_license(license_id):
     return Package.get_license_register().get(license_id)
 
 
+def get_package_keywords(language='en'):
+    '''Helper to return a list of the top 3 keywords based on specified
+    language.
+
+    List structure matches the get_facet_items_dict() helper which doesn't
+    load custom facets on the home page.
+    [{
+        'count': 1,
+        'display_name': u'English Tag',
+        'name': u'English Tag'
+    },
+    {
+        'count': 1,
+        'display_name': u'Second Tag',
+        'name': u'Second Tag'
+    }]
+    '''
+    facet = "keywords_{}".format(language)
+    package_top_keywords = toolkit.get_action('package_search')(
+        data_dict={'facet.field': [facet],
+                   'facet.limit': 3,
+                   'rows': 0})
+    package_top_keywords = package_top_keywords['search_facets'][facet]['items']
+    return package_top_keywords
+
+
 def default_locale():
     '''Wrap the ckan default locale in a helper function to access
     in templates.
@@ -269,7 +295,8 @@ class OntarioThemePlugin(plugins.SingletonPlugin):
 
     def get_helpers(self):
         return {'ontario_theme_get_license': get_license,
-                'extrafields_default_locale': default_locale}
+                'extrafields_default_locale': default_locale,
+                'ontario_theme_get_package_keywords': get_package_keywords}
 
     # IBlueprint
 

--- a/ckanext/ontario_theme/templates/group/read.html
+++ b/ckanext/ontario_theme/templates/group/read.html
@@ -1,17 +1,34 @@
 {#
 
 Override CKAN's read.html to add some new facets.
+To prevent calling super() in all other blocks I'm using ckan_extends and
+loading in the snippet directly instead of using super() in the secondary
+block. super() will end up calling the facets twice.
 
 #}
 
-{% extends "group/read_base.html" %}
+{% ckan_extends %}
 
 {% block secondary_content %}
-  {{ super() }}
+  {% snippet "group/snippets/info.html", group=c.group_dict, show_nums=true %}
   <div class="filters">
     <div>
+      {{ h.snippet('snippets/ontario_theme_keywords_facet.html',
+      extras={'id':c.group_dict.id}) }}
+      {# 
+        Flag facets to be ignored from standard loop that calls facets.
+      #}
+      {% set excluded_facets = [
+        'keywords_en',
+        'keywords_fr'
+        ]
+      %}
+    </div>
+    <div>
       {% for facet in c.facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+        {% if facet not in excluded_facets %}
+          {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+        {% endif %}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckanext/ontario_theme/templates/group/read.html
+++ b/ckanext/ontario_theme/templates/group/read.html
@@ -1,0 +1,19 @@
+{#
+
+Override CKAN's read.html to add some new facets.
+
+#}
+
+{% extends "group/read_base.html" %}
+
+{% block secondary_content %}
+  {{ super() }}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/home/snippets/search.html
+++ b/ckanext/ontario_theme/templates/home/snippets/search.html
@@ -3,7 +3,7 @@
 Renders a custom search component for the home page.
 
 #}
-{% set tags = h.get_facet_items_dict('tags', limit=3) %}
+{% set keywords = h.ontario_theme_get_package_keywords(h.lang()) %}
 {% set placeholder = _('E.g. environment') %}
 
 <div class="module search">
@@ -18,9 +18,15 @@ Renders a custom search component for the home page.
     </div>
   </form>
   <div class="tags">
-    <h3>{{ _('Popular tags') }}</h3>
-    {% for tag in tags %}
-      <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.truncate(tag.display_name, 22) }}</a>
+    <h3>{{ _('Popular keywords') }}</h3>
+    {% for keyword in keywords %}
+      {% if h.lang() == 'en' %}
+        <a class="tag" href="{% url_for controller='package', action='search',
+        keywords_en=keyword.name %}">{{ h.truncate(keyword.display_name, 22) }}</a>
+      {% elif h.lang() == 'fr' %}
+        <a class="tag" href="{% url_for controller='package', action='search',
+        keywords_fr=keyword.name %}">{{ h.truncate(keyword.display_name, 22) }}</a>
+      {% endif %}
     {% endfor %}
   </div>
 </div>

--- a/ckanext/ontario_theme/templates/organization/read.html
+++ b/ckanext/ontario_theme/templates/organization/read.html
@@ -1,0 +1,18 @@
+{#
+
+Override CKAN's read.html to add some new facets.
+
+#}
+
+{% ckan_extends %}
+
+{% block organization_facets %}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/organization/read.html
+++ b/ckanext/ontario_theme/templates/organization/read.html
@@ -9,8 +9,23 @@ Override CKAN's read.html to add some new facets.
 {% block organization_facets %}
   <div class="filters">
     <div>
+      {{ h.snippet('snippets/ontario_theme_keywords_facet.html',
+      extras={'id':c.group_dict.id}) }}
+      {# 
+        Flag facets to be ignored from standard loop that calls facets.
+      #}
+      {% set excluded_facets = [
+        'keywords_en',
+        'keywords_fr'
+        ]
+      %}
+    </div>
+    <div>
+
       {% for facet in c.facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+        {% if facet not in excluded_facets %}
+          {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+        {% endif %}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckanext/ontario_theme/templates/package/search.html
+++ b/ckanext/ontario_theme/templates/package/search.html
@@ -88,9 +88,24 @@ in the core template for search.html.
         {% endblock %}
       </section>
     </div>
+
+  <div>
+    {{ h.snippet('snippets/ontario_theme_keywords_facet.html') }}
+    {# 
+      Flag facets to be ignored from standard loop that calls facets.
+    #}
+    {% set excluded_facets = [
+      'keywords_en',
+      'keywords_fr'
+      ]
+    %}
+  </div>
+
   <div>
     {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+      {% if facet not in excluded_facets %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+      {% endif %}
     {% endfor %}
   </div>
   <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckanext/ontario_theme/templates/scheming/display_snippets/fluent_tags.html
+++ b/ckanext/ontario_theme/templates/scheming/display_snippets/fluent_tags.html
@@ -1,0 +1,16 @@
+{# slight abuse of scheming_language_text for selecting the desired
+   language version #}
+{%- set value = h.scheming_language_text(data[field.field_name]) -%}
+<section class="tags">
+{% block tag_list %}
+  <ul class="tag-list">
+    {% for tag in value %}
+      <li>
+        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{%
+          url_for controller='package', action='search', tags=tag %}">{{
+            h.truncate(tag, 22) }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}
+<section class="tags">

--- a/ckanext/ontario_theme/templates/scheming/display_snippets/fluent_tags.html
+++ b/ckanext/ontario_theme/templates/scheming/display_snippets/fluent_tags.html
@@ -1,16 +1,30 @@
-{# slight abuse of scheming_language_text for selecting the desired
-   language version #}
+{#
+
+Customizes fluent's template to set proper search key based on language (e.g.
+tags=tags changes to keywords_en=tag).
+FYI - Fluent's template is an override of schemings already.
+
+#}
+
 {%- set value = h.scheming_language_text(data[field.field_name]) -%}
 <section class="tags">
 {% block tag_list %}
   <ul class="tag-list">
     {% for tag in value %}
-      <li>
-        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{%
-          url_for controller='package', action='search', tags=tag %}">{{
-            h.truncate(tag, 22) }}</a>
-      </li>
+      {% if h.lang() == 'en' %}
+        <li>
+          <a class="tag" href="{%
+            url_for controller='package', action='search', keywords_en=tag
+            %}">{{ h.truncate(tag, 22) }}</a>
+        </li>
+      {% else %}
+        <li>
+          <a class="tag" href="{%
+            url_for controller='package', action='search', keywords_fr=tag
+            %}">{{ h.truncate(tag, 22) }}</a>
+        </li>
+      {% endif %}
     {% endfor %}
   </ul>
 {% endblock %}
-<section class="tags">
+</section>

--- a/ckanext/ontario_theme/templates/snippets/ontario_theme_keywords_facet.html
+++ b/ckanext/ontario_theme/templates/snippets/ontario_theme_keywords_facet.html
@@ -1,0 +1,14 @@
+{#
+
+Custom snippet to handle calling the the right keyword facet based on
+language.
+
+#}
+
+{% if h.lang() == 'en' %}
+  {{ h.snippet('snippets/facet_list.html',
+  title=c.facet_titles['keywords_en'], name='keywords_en', extras=extras) }}
+{% elif h.lang() == 'fr' %}
+  {{ h.snippet('snippets/facet_list.html',
+  title=c.facet_titles['keywords_fr'], name='keywords_fr', extras=extras) }}
+{% endif %}

--- a/ckanext/ontario_theme/tests/test_helpers.py
+++ b/ckanext/ontario_theme/tests/test_helpers.py
@@ -5,10 +5,15 @@
 import nose.tools
 import json
 import os
+import ckan.tests.helpers as helpers
+import ckan.model as model
+import ckan.plugins as plugins
+import ckan.lib.search as search
 from ckan.common import config
 from ckanext.ontario_theme.plugin import (
     get_license,
-    default_locale
+    default_locale,
+    get_package_keywords
 )
 assert_equals = nose.tools.assert_equals
 
@@ -28,3 +33,99 @@ class TestDefaultLocale(object):
     def test_default_locale_returns_proper_value(self):
         default = config.get('ckan.locale_default', 'en')
         assert_equals(default_locale(), default)
+
+
+class TestGetPackageKeywords(object):
+    @classmethod
+    def setup_class(cls):
+        '''Nose runs this method once to setup our test class.'''
+        # Test code should use CKAN's plugins.load() function to load plugins
+        # to be tested.
+        plugins.load('ontario_theme')
+
+        cls.package_index = search.PackageSearchIndex()
+
+    def teardown(self):
+        '''Nose runs this method after each test method in our test class.'''
+        # Rebuild CKAN's database after each test method, so that each test
+        # method runs with a clean slate.
+        model.repo.rebuild_db()
+        # clear the search index after every test.
+        # This is needed because the count that is received from the keywords
+        # helper is from solr. Solr wasn't clearing the index so the count
+        # kept incrementing and throwing failing tests. Check CKAN's search
+        # tests for larger examples.
+        self.package_index.clear()
+
+    @classmethod
+    def teardown_class(cls):
+        '''Nose runs this method once after all the test methods in our class
+        have been run.
+
+        '''
+        # We have to unload the plugin we loaded, so it doesn't affect any
+        # tests that run after ours.
+        plugins.unload('ontario_theme')
+
+    def test_get_package_keywords_returns_english_as_default(self):
+        dataset = helpers.call_action(
+                'package_create',
+                name='package-name',
+                maintainer='Joe Smith',
+                maintainer_email='Joe.Smith@ontario.ca',
+                title_translated={
+                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
+                notes_translated={'en': u'short description', 'fr': u'...'},
+                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
+                )
+        # Make sure package was returned as expected.
+        assert_equals(dataset['name'], 'package-name')
+        # Expected keyword list based on dataset above.
+        keywords = [{
+                'count': 1,
+                'display_name': u'English Tag',
+                'name': u'English Tag'
+            }]
+        assert_equals(get_package_keywords(), keywords)
+
+    def test_get_package_keywords_returns_english(self):
+        dataset = helpers.call_action(
+                'package_create',
+                name='package-name',
+                maintainer='Joe Smith',
+                maintainer_email='Joe.Smith@ontario.ca',
+                title_translated={
+                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
+                notes_translated={'en': u'short description', 'fr': u'...'},
+                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
+                )
+        # Make sure package was returned as expected.
+        assert_equals(dataset['name'], 'package-name')
+        # Expected keyword list based on dataset above.
+        keywords = [{
+                'count': 1,
+                'display_name': u'English Tag',
+                'name': u'English Tag'
+            }]
+        assert_equals(get_package_keywords(language='en'), keywords)
+
+    def test_get_package_keywords_returns_french(self):
+        dataset = helpers.call_action(
+                'package_create',
+                name='package-name',
+                maintainer='Joe Smith',
+                maintainer_email='Joe.Smith@ontario.ca',
+                title_translated={
+                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
+                notes_translated={'en': u'short description', 'fr': u'...'},
+                keywords={'en': [u'English Tag'], 'fr': [u'French Tag']}
+                )
+        # Make sure package was returned as expected.
+        assert_equals(dataset['name'], 'package-name')
+        # Expected keyword list based on dataset above.
+        keywords = [{
+                'count': 1,
+                'display_name': u'French Tag',
+                'name': u'French Tag'
+            }]
+        assert_equals(get_package_keywords(language='fr'), keywords)

--- a/ckanext/ontario_theme/tests/test_helpers.py
+++ b/ckanext/ontario_theme/tests/test_helpers.py
@@ -129,3 +129,30 @@ class TestGetPackageKeywords(object):
                 'name': u'French Tag'
             }]
         assert_equals(get_package_keywords(language='fr'), keywords)
+
+    def test_get_package_keywords_returns_multiple_values(self):
+        dataset = helpers.call_action(
+                'package_create',
+                name='package-name',
+                maintainer='Joe Smith',
+                maintainer_email='Joe.Smith@ontario.ca',
+                title_translated={
+                    'en': u'A Novel By Tolstoy', 'fr':u'Un novel par Tolstoy'},
+                notes_translated={'en': u'short description', 'fr': u'...'},
+                keywords={'en': [u'English Tag', u'English Tag 2'], 'fr': 
+                [u'French Tag', u'French Tag 2', u'French Tag 3']}
+                )
+        # Make sure package was returned as expected.
+        assert_equals(dataset['name'], 'package-name')
+        # Expected keyword list based on dataset above.
+        keywords = [{
+                'count': 1,
+                'display_name': u'English Tag 2',
+                'name': u'English Tag 2'
+            },
+            {
+                'count': 1,
+                'display_name': u'English Tag',
+                'name': u'English Tag'
+            }]
+        assert_equals(get_package_keywords(), keywords)

--- a/config/solr/schema.xml
+++ b/config/solr/schema.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+     NB Please copy changes to this file into the multilingual schema:
+        ckanext/multilingual/solr/schema.xml
+-->
+
+<!-- We update the version when there is a backward-incompatible change to this
+schema. In this case the version should be set to the next CKAN version number.
+(x.y but not x.y.z since it needs to be a float) -->
+<schema name="ckan" version="2.8">
+
+<types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="binary" class="solr.BinaryField"/>
+    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+
+    <fieldType name="tdates" class="solr.TrieDateField" precisionStep="7" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+    <fieldType name="tints" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="tfloats" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="tlongs" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="tdoubles" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
+
+    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <!-- A general unstemmed text field - good if one does not know the language of the field -->
+    <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+</types>
+
+
+<fields>
+    <field name="index_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="id" type="string" indexed="true" stored="true" required="true" />
+    <field name="site_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="title" type="text" indexed="true" stored="true" />
+    <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="dataset_type" type="string" indexed="true" stored="true" />
+    <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="version" type="string" indexed="true" stored="true" />
+    <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="ckan_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="download_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="notes" type="text" indexed="true" stored="true"/>
+    <field name="author" type="textgen" indexed="true" stored="true" />
+    <field name="author_email" type="textgen" indexed="true" stored="true" />
+    <field name="maintainer" type="textgen" indexed="true" stored="true" />
+    <field name="maintainer_email" type="textgen" indexed="true" stored="true" />
+    <field name="license" type="string" indexed="true" stored="true" />
+    <field name="license_id" type="string" indexed="true" stored="true" />
+    <field name="ratings_count" type="int" indexed="true" stored="false" />
+    <field name="ratings_average" type="float" indexed="true" stored="false" />
+    <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="permission_labels" type="string" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="res_name" type="textgen" indexed="true" stored="true" multiValued="true" />
+    <field name="res_description" type="textgen" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
+
+    <!-- catchall field, containing all other searchable text fields (implemented
+         via copyField further on in this schema  -->
+    <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="urls" type="text" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="depends_on" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="dependency_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="derives_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="has_derivation" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="links_to" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="linked_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="child_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="parent_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="views_total" type="int" indexed="true" stored="false"/>
+    <field name="views_recent" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
+
+    <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
+    <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="indexed_ts" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+    <!-- Copy the title field into titleString, and treat as a string
+         (rather than text type).  This allows us to sort on the titleString -->
+    <field name="title_string" type="string" indexed="true" stored="false" />
+
+    <field name="data_dict" type="string" indexed="false" stored="true" />
+    <field name="validated_data_dict" type="string" indexed="false" stored="true" />
+
+    <field name="_version_" type="string" indexed="true" stored="true"/>
+
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*" type="string" indexed="true"  stored="false"/>
+</fields>
+
+<uniqueKey>index_id</uniqueKey>
+<defaultSearchField>text</defaultSearchField>
+<solrQueryParser defaultOperator="AND"/>
+
+<copyField source="url" dest="urls"/>
+<copyField source="ckan_url" dest="urls"/>
+<copyField source="download_url" dest="urls"/>
+<copyField source="res_url" dest="urls"/>
+<copyField source="extras_*" dest="text"/>
+<copyField source="res_extras_*" dest="text"/>
+<copyField source="vocab_*" dest="text"/>
+<copyField source="urls" dest="text"/>
+<copyField source="name" dest="text"/>
+<copyField source="title" dest="text"/>
+<copyField source="text" dest="text"/>
+<copyField source="license" dest="text"/>
+<copyField source="notes" dest="text"/>
+<copyField source="tags" dest="text"/>
+<copyField source="groups" dest="text"/>
+<copyField source="organization" dest="text"/>
+<copyField source="res_name" dest="text"/>
+<copyField source="res_description" dest="text"/>
+<copyField source="maintainer" dest="text"/>
+<copyField source="author" dest="text"/>
+
+</schema>

--- a/config/solr/schema.xml
+++ b/config/solr/schema.xml
@@ -156,6 +156,10 @@ schema. In this case the version should be set to the next CKAN version number.
     <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*" type="string" indexed="true"  stored="false"/>
+
+    <!-- Extra Ontario fields -->
+    <field name="keywords_en" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="keywords_fr" type="string" indexed="true" stored="true" multiValued="true"/>
 </fields>
 
 <uniqueKey>index_id</uniqueKey>


### PR DESCRIPTION
Fluent doesn't support multi-lingual tag support out of the box.
Keywords are used in their place as per the fluent readme.
The default behaviour in fluent adds mutli-lingual keywords in forms
and helps display them properly when toggling languages but when adding
them as facets extra work is needed (fluent basically offers multi-lingual
read and write abilities for tags but nothing for search).

Changes include:

- Adding new keywords as facets
- Refactor *_facet() functions in plugin.py
- Index new facets
- Add and update various templates to get new keywords to appear properly throughout
- Add custom helper to get top keywords by language and display on homepage
- New helper tests
- New custom solr schema to add multiValued keyword support
