### PR TITLE
Odc beta schema updates

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -383,7 +383,7 @@
       "form_placeholder": "e.g., Users will need to register with the website to recieve a login and provide an email address. Visit http://www.example.com/register."
     },
     {
-      "field_name": "licence_id",
+      "field_name": "license_id",
       "label": {
         "en": "Licence",
         "fr": "Licence"

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -561,22 +561,6 @@
       "preset": "fluent_markdown"
     },
     {
-      "field_name": "cluster_application_id",
-      "label": {
-        "en": "Cluster Application ID",
-        "fr": "Identifiant d'application"
-      },
-      "help_inline" : true,
-      "help_text": {
-        "en": "Is this information sourced from or used in an OPS software application? If so, which one?"
-      }, 
-      "classes": ["form-group","col-md-12"],
-      "fieldset": 7,
-      "fieldset_name": "Making Connections",
-      "fieldset_subtitle": "Help us map OPS assets.",
-      "form_placeholder": "CI0000000000000"
-    },
-    {
       "field_name": "node_id",
       "label": {
         "en": "Ontario node ID",

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -577,19 +577,6 @@
       "form_placeholder": "CI0000000000000"
     },
     {
-      "field_name": "go_program_id",
-      "label": {
-        "en": "OPS Program ID",
-        "fr": "Identifiant du programme"
-      },
-      "help_inline" : true,
-      "help_text": {
-        "en": "Did this information support an OPS program? If so, which one?"
-      }, 
-      "classes": ["form-group","col-md-12"],
-      "form_placeholder": "P00000"
-    },
-    {
       "field_name": "node_id",
       "label": {
         "en": "Ontario node ID",

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -397,36 +397,6 @@
       "classes": ["col-md-12","form-group"]
     },
     {
-      "field_name": "licence_range_start",
-      "label": {
-        "en": "Licence range start",
-        "fr": "Début de licence"
-      },
-      "help_inline" : true,
-      "help_text": {
-        "en": "Does the licence have an expiry or applicable time period? When does it start?"
-      },  
-      "classes": ["form-group","col-md-12"],    
-      "preset": "date",
-      "validators": "ignore_missing isodate convert_to_json_if_date",
-      "form_placeholder": "yyyy-mm-dd"
-    },
-    {
-      "field_name": "licence_range_end",
-      "label": {
-        "en": "Licence range end",
-        "fr": "Fin de licence"
-      },
-      "help_inline" : true,
-      "help_text": {
-        "en": "Does the licence have an expiry or applicable time period? When does it end?"
-      },  
-      "classes": ["form-group","col-md-12"],
-      "preset": "date",
-      "validators": "ignore_missing isodate convert_to_json_if_date",
-      "form_placeholder": "yyyy-mm-dd"
-    },  
-    {
       "field_name": "access_level",
       "label": {
         "en": "Access level",

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -667,6 +667,13 @@
             "en": "French",
             "fr": "Français"
           }
+        },
+        {
+          "value": "english_and_french",
+          "label": {
+            "en": "English and French",
+            "fr": "Anglais et Français"
+          }
         }
       ]
     }, 


### PR DESCRIPTION
This PR consists of 5 commits and focuses on schema changes for the public catalogue based on the first round of feedback on our pilot schema:

- removing the following fields from the schema because they are specific to colby (and will never be populated on the public catalogue):
  - program id
  - cluster application id
  - licence range start
  - licence range end
- changing licence_id field name back to original license_id in order to not break core ckan
- adding a "french and english" option to resource language field