### PR TITLE
Bug: Let user click first quarter of search form.

### DIFF
--- a/ckanext/ontario_theme/templates/organization/index.html
+++ b/ckanext/ontario_theme/templates/organization/index.html
@@ -3,19 +3,26 @@
 {% block page_primary_action %}
 {% endblock %}
 
-{% block pre_primary %}
-  <div class="page_primary_action">
-    <div class="add-organization">
-    {% if h.check_access('organization_create') %}
-      {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
-    {% endif %}
+{% block ontario_theme_search_form %}
+  {# Custom block for search form. #}
+  <div class="row no-padding">
+    <div class="page_primary_action">
+      <div class="add-organization">
+      {% if h.check_access('organization_create') %}
+        {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
+      {% endif %}
+      </div>
     </div>
+    <h1 class="hide-heading">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
+    {% block organizations_search_form %}
+      {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+    {% endblock %}
   </div>
-  <h1 class="hide-heading">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
-  {% block organizations_search_form %}
-    {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
-  {% endblock %}
 {% endblock %}
+
+{% block pre_primary %}
+{% endblock %}
+
 {% block primary_content_inner %}
   {% block organizations_list %}
     {% if c.page.items or request.params %}

--- a/ckanext/ontario_theme/templates/package/search.html
+++ b/ckanext/ontario_theme/templates/package/search.html
@@ -9,33 +9,38 @@ in the core template for search.html.
 
 {% ckan_extends %}
 
+{% block ontario_theme_search_form %}
+  <div class="row no-padding">
+    {# Lifting these block above main content. #}
+
+    {% block page_primary_action %}
+      {{ super() }}
+    {% endblock %}
+
+    {% block form %}
+      {% set facets = {
+        'fields': c.fields_grouped,
+        'search': c.search_facets,
+        'titles': c.facet_titles,
+        'translated_fields': c.translated_fields,
+        'remove_field': c.remove_field }
+      %}
+      {% set sorting = [
+        (_('Relevance'), 'score desc, metadata_modified desc'),
+        (_('Name Ascending'), 'title_string asc'),
+        (_('Name Descending'), 'title_string desc'),
+        (_('Last Modified'), 'metadata_modified desc'),
+        (_('Recently Created'), 'dataset_published_date desc'),
+        (_('Datasets With Data'), 'num_resources desc, metadata_modified desc'),
+        (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+      %}
+      {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+
+    {% endblock %}
+  </div>
+{% endblock %}
+
 {% block pre_primary %}
-  {# Lifting these block above main content. #}
-
-  {% block page_primary_action %}
-    {{ super() }}
-  {% endblock %}
-
-  {% block form %}
-    {% set facets = {
-      'fields': c.fields_grouped,
-      'search': c.search_facets,
-      'titles': c.facet_titles,
-      'translated_fields': c.translated_fields,
-      'remove_field': c.remove_field }
-    %}
-    {% set sorting = [
-      (_('Relevance'), 'score desc, metadata_modified desc'),
-      (_('Name Ascending'), 'title_string asc'),
-      (_('Name Descending'), 'title_string desc'),
-      (_('Last Modified'), 'metadata_modified desc'),
-      (_('Recently Created'), 'dataset_published_date desc'),
-      (_('Datasets With Data'), 'num_resources desc, metadata_modified desc'),
-      (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
-    %}
-    {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
-
-  {% endblock %}
 {% endblock %}
 
 {% block primary_content %}

--- a/ckanext/ontario_theme/templates/page.html
+++ b/ckanext/ontario_theme/templates/page.html
@@ -3,3 +3,98 @@
 {% block skip %}
   <a href="#content" class="skip-main">{{ _('Skip to content') }}</a> 
 {% endblock %}
+
+{% block main_content %}
+  {% block flash %}
+    <div class="flash-messages">
+      {% block flash_inner %}
+        {% for message in h.flash.pop_messages() | list %}
+          <div class="alert alert-warning fade in {{ message.category }}">
+            {{ h.literal(message) }}
+          </div>
+        {% endfor %}
+      {% endblock %}
+    </div>
+  {% endblock %}
+
+  {% block toolbar %}
+    <div class="toolbar">
+      {% block breadcrumb %}
+        {% if self.breadcrumb_content() | trim %}
+          <ol class="breadcrumb">
+            {% snippet 'snippets/home_breadcrumb_item.html' %}
+            {% block breadcrumb_content %}{% endblock %}
+          </ol>
+        {% endif %}
+      {% endblock %}
+    </div>
+  {% endblock %}
+
+  <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
+    {#
+    The pre_primary block can be used to add content to before the
+    rendering of the main content columns of the page.
+    #}
+    {% block pre_primary %}
+    {% endblock %}
+
+    {% block secondary %}
+      <aside class="secondary col-sm-3">
+        {#
+        The secondary_content block can be used to add content to the
+        sidebar of the page. This is the main block that is likely to be
+        used within a template.
+
+        Example:
+
+          {% block secondary_content %}
+            <h2>A sidebar item</h2>
+            <p>Some content for the item</p>
+          {% endblock %}
+        #}
+        {% block secondary_content %}{% endblock %}
+      </aside>
+    {% endblock %}
+
+    {% block primary %}
+      <div class="primary col-sm-9 col-xs-12">
+        {#
+        The primary_content block can be used to add content to the page.
+        This is the main block that is likely to be used within a template.
+
+        Example:
+
+          {% block primary_content %}
+            <h1>My page content</h1>
+            <p>Some content for the page</p>
+          {% endblock %}
+        #}
+        {% block primary_content %}
+          <article class="module">
+            {% block page_header %}
+              <header class="module-content page-header">
+                {% if self.content_action() | trim %}
+                  <div class="content_action">
+                    {% block content_action %}{% endblock %}
+                  </div>
+                {% endif %}
+                <ul class="nav nav-tabs">
+                  {% block content_primary_nav %}{% endblock %}
+                </ul>
+              </header>
+            {% endblock %}
+            <div class="module-content">
+              {% if self.page_primary_action() | trim %}
+                <div class="page_primary_action">
+                  {% block page_primary_action %}{% endblock %}
+                </div>
+              {% endif %}
+              {% block primary_content_inner %}
+              {% endblock %}
+            </div>
+          </article>
+        {% endblock %}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/page.html
+++ b/ckanext/ontario_theme/templates/page.html
@@ -6,30 +6,17 @@
 
 {% block main_content %}
   {% block flash %}
-    <div class="flash-messages">
-      {% block flash_inner %}
-        {% for message in h.flash.pop_messages() | list %}
-          <div class="alert alert-warning fade in {{ message.category }}">
-            {{ h.literal(message) }}
-          </div>
-        {% endfor %}
-      {% endblock %}
-    </div>
+    {{ super() }}
   {% endblock %}
 
   {% block toolbar %}
-    <div class="toolbar">
-      {% block breadcrumb %}
-        {% if self.breadcrumb_content() | trim %}
-          <ol class="breadcrumb">
-            {% snippet 'snippets/home_breadcrumb_item.html' %}
-            {% block breadcrumb_content %}{% endblock %}
-          </ol>
-        {% endif %}
-      {% endblock %}
-    </div>
+    {{ super() }}
   {% endblock %}
 
+  {% block ontario_theme_search_form %}
+    {# Custom block for search form. #}
+  {% endblock %}
+  
   <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
     {#
     The pre_primary block can be used to add content to before the
@@ -39,62 +26,11 @@
     {% endblock %}
 
     {% block secondary %}
-      <aside class="secondary col-sm-3">
-        {#
-        The secondary_content block can be used to add content to the
-        sidebar of the page. This is the main block that is likely to be
-        used within a template.
-
-        Example:
-
-          {% block secondary_content %}
-            <h2>A sidebar item</h2>
-            <p>Some content for the item</p>
-          {% endblock %}
-        #}
-        {% block secondary_content %}{% endblock %}
-      </aside>
+      {{ super() }}
     {% endblock %}
 
     {% block primary %}
-      <div class="primary col-sm-9 col-xs-12">
-        {#
-        The primary_content block can be used to add content to the page.
-        This is the main block that is likely to be used within a template.
-
-        Example:
-
-          {% block primary_content %}
-            <h1>My page content</h1>
-            <p>Some content for the page</p>
-          {% endblock %}
-        #}
-        {% block primary_content %}
-          <article class="module">
-            {% block page_header %}
-              <header class="module-content page-header">
-                {% if self.content_action() | trim %}
-                  <div class="content_action">
-                    {% block content_action %}{% endblock %}
-                  </div>
-                {% endif %}
-                <ul class="nav nav-tabs">
-                  {% block content_primary_nav %}{% endblock %}
-                </ul>
-              </header>
-            {% endblock %}
-            <div class="module-content">
-              {% if self.page_primary_action() | trim %}
-                <div class="page_primary_action">
-                  {% block page_primary_action %}{% endblock %}
-                </div>
-              {% endif %}
-              {% block primary_content_inner %}
-              {% endblock %}
-            </div>
-          </article>
-        {% endblock %}
-      </div>
+      {{ super() }}
     {% endblock %}
   </div>
 {% endblock %}


### PR DESCRIPTION
**Expected Behaviour:** The user can click into the search input fields on the dataset (package) and organization main pages where the search input is full width.

**Actual Behaviour:** The first quarter of the search input field is not clickable. The `wrapper` class that is used to create a 2 column layout has a `::before` selector that stretches to the top of the wrapper preventing a user from clicking on anything visible but underneath it (e.g. the search field and the filters that may be applied to the search results).

**Fix:** Create a custom block in the `page.html` template that we can use in templates extending it. Then "lift" the search form into this block. This only applies to the organization and dataset (package) search pages. Full width search hasn't been applied to the groups yet.