### PR TITLE
Improvement: Fix resource description overlap and display.

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -431,13 +431,9 @@ div.add-dataset {
 .media-view {
   border: none;
 }
-li.resource-item > div {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 20px;
-  height: 30px;
-  margin: auto;
+.resource-item .format-label {
+  top: 0px;
+  left: -35px;
 }
 .hero {
   background-image: none;
@@ -538,23 +534,6 @@ table.table tbody tr td.dataset-details {
 @media (min-width: 768px) {
   .wrapper:before {
     border-right: none;
-  }
-}
-/* =====================================================
-   Move resource items buttons under resource title in smaller screen
-   ===================================================== */
-@media (max-width: 768px) {
-  li.resource-item {
-    float: left;
-    width: 100%;
-  }
-  li.resource-item > div {
-    right: 0px;
-    position: relative;
-  }
-  li.resource-item > div a {
-    float: right;
-    margin: 2px;
   }
 }
 /* =====================================================

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -127,16 +127,10 @@ div.add-dataset {
 .media-view {
   border: none;
 }
-
-li.resource-item>div {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 20px;
-  height: 30px;
-  margin: auto;
+.resource-item .format-label {
+    top: 0px;
+    left: -35px;
 }
-
 .hero {
   background-image: none;
   background: linear-gradient(0deg,rgba(0,0,0,.3),rgba(0,0,0,0.3)), url(/images/backgrounds/richard-balog-647377-unsplash_converted.jpg);
@@ -247,26 +241,6 @@ table.table {
 @media (min-width: 768px) {
   .wrapper:before {
       border-right: none;
-  }
-}
-
-/* =====================================================
-   Move resource items buttons under resource title in smaller screen
-   ===================================================== */
-
-@media (max-width: 768px) {
-  li.resource-item {
-    float: left;
-    width: 100%;
-    &>div {
-      //float: right;
-      right: 0px;
-      position: relative;
-      a {
-        float: right;
-        margin: 2px;
-      }
-    }
   }
 }
 

--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -641,11 +641,12 @@
       "classes": ["form-group","col-md-12"] 
     },
     {
-      "field_name": "description",
+      "field_name": "description_translated",
       "label": {
         "en": "Description",
         "fr": "Description"
       },
+      "preset": "fluent_core_translated",
       "form_snippet": "fluent_markdown.html",
       "classes": ["form-group","col-md-12"],
       "form_placeholder": "Some useful notes about the file"

--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -1,48 +1,67 @@
-{% ckan_extends %}
+{#
+  Complete override of template to make each list item a row with 2 columns. No parent block in this snippet so I've had to override 
+  whole thing. 
+  The translation of description worked fine here assuming the field was translated in the schema.
+#}
 
-{% block resource_item_title %}
-<a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
-  {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> 
-  {% if res.size %}
-    <span class="text-muted small"> 
-      ({{ h.localised_filesize(res.size) }})
-    </span>
-  {% endif %}
-  {{ h.popular('views', res.tracking_summary.total, min=10) }}
-</a>
-{% endblock %}
+{% set url_action = 'resource_edit' if url_is_edit and can_edit else 'resource_read' %}
+{% set url = h.url_for(controller='package', action=url_action, id=pkg.name, resource_id=res.id) %}
 
-{% block resource_item_explore %}
-  {% if not url_is_edit %}
-  <div>
-    {% block resource_item_explore_links %}
-        <a href="{{ url }}" class="btn btn-primary">
-          {% if res.has_views %}
-            <i class="fa fa-bar-chart-o"></i>
-            {{ _('Preview') }}
-          {% else %}
-            <i class="fa fa-info-circle"></i>
-            {{ _('About') }}
+<li class="resource-item row" data-id="{{ res.id }}">
+  <div class="col-md-6 col-xs-12">
+    {% block resource_item_title %}
+      <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
+        {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span> 
+        {% if res.size %}
+          <span class="text-muted small"> 
+            ({{ h.localised_filesize(res.size) }})
+          </span>
+        {% endif %}
+        {{ h.popular('views', res.tracking_summary.total, min=10) }}
+      </a>
+    {% endblock %}
+    {% block resource_item_description %}
+      <p class="description">
+        {% if res.description %}
+          {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
+        {% endif %}
+      </p>
+    {% endblock %}
+  </div>
+  <div class="col-md-6 col-xs-12 text-right">
+    {% block resource_item_explore %}
+      {% if not url_is_edit %}
+      <div>
+        {% block resource_item_explore_links %}
+            <a href="{{ url }}" class="btn btn-primary">
+              {% if res.has_views %}
+                <i class="fa fa-bar-chart-o"></i>
+                {{ _('Preview') }}
+              {% else %}
+                <i class="fa fa-info-circle"></i>
+                {{ _('About') }}
+              {% endif %}
+            </a>
+          {% if res.url and h.is_url(res.url) %}
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary" target="_blank">
+              {% if res.has_views or res.url_type == 'upload' %}
+                <i class="fa fa-arrow-circle-o-down"></i>
+                {{ _('Download') }}
+              {% else %}
+                <i class="fa fa-external-link"></i>
+                {{ _('Open') }}
+              {% endif %}
+            </a>
           {% endif %}
-        </a>
-      {% if res.url and h.is_url(res.url) %}
-        <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary" target="_blank">
-          {% if res.has_views or res.url_type == 'upload' %}
-            <i class="fa fa-arrow-circle-o-down"></i>
-            {{ _('Download') }}
-          {% else %}
-            <i class="fa fa-external-link"></i>
-            {{ _('Open') }}
+          {% if can_edit %}
+            <a href="{{ h.url_for(controller='package', action='resource_edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
+              <i class="fa fa-pencil-square-o"></i>
+              {{ _('Edit') }}
+            </a>
           {% endif %}
-        </a>
-      {% endif %}
-      {% if can_edit %}
-        <a href="{{ h.url_for(controller='package', action='resource_edit', id=pkg.name, resource_id=res.id) }}" class="btn btn-primary">
-          <i class="fa fa-pencil-square-o"></i>
-          {{ _('Edit') }}
-        </a>
+        {% endblock %}
+      </div>
       {% endif %}
     {% endblock %}
   </div>
-  {% endif %}
-{% endblock %}
+</li>

--- a/ckanext/ontario_theme/templates/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/scheming/package/resource_read.html
@@ -1,13 +1,94 @@
-{% ckan_extends %}
+{#
+  Override scheming to modify the excluded_fields and set the 
+  bi-lingual description for resources.
+#}
+{% extends "package/resource_read.html" %}
 
-{%- block resource_format -%}
-  <tr>
-    <th scope="row">{{ _('Format') }}</th>
-    <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
-  </tr>
-  {# Add resource size if known. This extends scheming's template. #}
-  <tr>
-    <th scope="row">File size</th>
-    <td>{{ h.localised_filesize(res.size) if res.size else _('unknown size') }}</td>
-  </tr>
-{%- endblock -%}
+{%- set exclude_fields = [
+    'name',
+    'description_translated',
+    'url',
+    'format',
+    ] -%}
+{%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
+
+{% block resource_content %}
+  {% block resource_read_title %}
+    {{ super() }}
+  {% endblock %}
+  {% block resource_read_url %}
+    {{ super() }}
+  {% endblock %}
+  <div class="prose notes" property="rdfs:label">
+    {% if res.description %}
+      {{ h.render_markdown(h.get_translated(res, "description")) }}
+    {% endif %}
+    {% if not res.description and c.package.notes %}
+      <h3>{{ _('From the dataset abstract') }}</h3>
+      <blockquote>{{ h.markdown_extract(h.get_translated(c.package, 'notes')) }}</blockquote>
+      <p>{% trans dataset=c.package.title, url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block resource_additional_information_inner %}
+  <div class="module-content">
+    <h2>{{ _('Additional Information') }}</h2>
+    <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Field') }}</th>
+          <th scope="col">{{ _('Value') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {%- block resource_last_updated -%}
+          <tr>
+            <th scope="row">{{ _('Last updated') }}</th>
+            <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
+          </tr>
+        {%- endblock -%}
+        {%- block resource_created -%}
+          <tr>
+            <th scope="row">{{ _('Created') }}</th>
+            <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
+          </tr>
+        {%- endblock -%}
+        {%- block resource_format -%}
+          <tr>
+            <th scope="row">{{ _('Format') }}</th>
+            <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
+          </tr>
+          {# Add resource size if known. This extends scheming's template. #}
+          <tr>
+            <th scope="row">File size</th>
+            <td>{{ h.localised_filesize(res.size) if res.size else _('unknown size') }}</td>
+          </tr>
+        {%- endblock -%}
+        {%- block resource_license -%}
+          <tr>
+            <th scope="row">{{ _('License') }}</th>
+            <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
+          </tr>
+        {%- endblock -%}
+        {%- block resource_fields -%}
+          {%- for field in schema.resource_fields -%}
+            {%- if field.field_name not in exclude_fields
+                and field.display_snippet is not none -%}
+              <tr>
+                <th scope="row">
+                  {{- h.scheming_language_text(field.label) -}}
+                </th>
+                <td>
+                  {%- snippet 'scheming/snippets/display_field.html',
+                      field=field, data=res, entity_type='dataset',
+                      object_type=dataset_type -%}
+                </td>
+              </tr>
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endblock -%}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}


### PR DESCRIPTION
**Overview:**

- Prevent resource description from overlapping buttons on package page
- Get resource description to show up on package page
- Get bi-lingual resource description to show up on resource page

**Details:** 

Make resource description (ckan core field) multi-lingual in schema.
This currently adds description-en, description-fr instead of _translated.
This was causing the description to not appear in the resource_item.html
because it was not being saved in description_translated or description field.
It was only being saved in description-en and description-fr oddly.

Restructure styles and resource_item.html to display resource details on
a package page in 2 columns. This fixes the description and button
overlap issue.

Override resource_item.html to make the resource display 2 columns
and prevent overlapping of buttons and text. Complete override
needed as there isn't a block wrapping the `<li>` element. Template
starts showing the description once schema is fixed.

Override resource_read.html to load multi-lingual descriptions.