### PR TITLE
Task: Implement dataset status snippet

### DIFF
--- a/ckanext/ontario_theme/fanstatic/labels.less
+++ b/ckanext/ontario_theme/fanstatic/labels.less
@@ -73,3 +73,23 @@
   height: 35px;
   background-position: -414px -62px;
 }
+
+.open,.under_review,.to_be_opened,.restricted {
+  color: #4d4d4d;
+}
+
+.open {
+  background-color: #e6fad2;
+}
+
+.under_review {
+  background: #d2d1eb;
+}
+
+.to_be_opened {
+  background-color: #dff3f3
+}
+
+.restricted {
+  background-color: #fad2d2;
+}

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -299,6 +299,21 @@ a.card:hover {
   height: 35px;
   background-position: -414px -62px;
 }
+.open,.under_review,.to_be_opened,.restricted {
+  color: #4d4d4d;
+}
+.open {
+  background-color: #e6fad2;
+}
+.under_review {
+  background: #d2d1eb;
+}
+.to_be_opened {
+  background-color: #dff3f3
+}
+.restricted {
+  background-color: #fad2d2;
+}
 .stats .number {
   display: block;
   font-size: 60px;

--- a/ckanext/ontario_theme/templates/scheming/package/read.html
+++ b/ckanext/ontario_theme/templates/scheming/package/read.html
@@ -21,6 +21,57 @@
       {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated'])) }}
     </div>
   {% endif %}
+  {% if h.scheming_field_by_name(schema.dataset_fields, 'access_level') and
+      pkg.access_level %}
+      <hr />
+      <strong>{{ _("Status") }}: </strong>
+      <span class="label {{ pkg['access_level'] }}">
+	  {{ h.scheming_choices_label(h.scheming_field_choices(h.scheming_field_by_name(schema.dataset_fields, 'access_level')), pkg['access_level']) }}
+      </span>
+      {% if pkg['access_level'] == 'open' %}
+        {% trans %}
+          <p>
+            Data in this record is open and is published in the language in which it’s collected. Please
+            <a href="https://www.ontario.ca/feedback/contact-us?id=14655&amp;nid=8691">
+              contact us
+            </a>
+            to obtain assistance in either official language.  
+          </p>      
+        {% endtrans %}
+        <p>
+          {% trans %}Data in this record was opened{% endtrans %} {{ h.scheming_language_text(pkg['opened_date']) }}.
+        </p>      
+      {% elif pkg['access_level'] == 'restricted' %}     
+        {% trans %}
+          <p>
+            Data in this record cannot be released because of legal, privacy, security, confidentiality or commercially-sensitive reasons, as outlined by the <a href="https://www.ontario.ca/page/ontarios-open-data-directive">Open Data Directive</a>. 
+          </p>
+        {% endtrans %}          
+          <p>
+            <strong>{{ h.scheming_language_text(h.scheming_field_by_name(schema.dataset_fields,"exemption").label) }}:</strong> 
+            {{ h.scheming_choices_label(h.scheming_field_choices(h.scheming_field_by_name(schema.dataset_fields,"exemption")),pkg['exemption']) }}
+          </p>
+          <p>
+            <strong>{{ h.scheming_language_text(h.scheming_field_by_name(schema.dataset_fields,"exemption_rationale").label) }}:</strong> 
+            {{ h.scheming_language_text(pkg['exemption_rationale']) }}
+          </p>
+      {% elif pkg['access_level'] == 'under_review' %}     
+        {% trans %}
+          <p>
+            We are reviewing the data in this record to determine if it can be made open, in support of the
+            <a href="http://www.ontario.ca/page/ontarios-open-data-directive">Open Data Directive</a>.
+          </p>
+        {% endtrans %}
+      {% elif pkg['access_level'] == 'to_be_opened' %}     
+        {% trans %}
+          <p>
+            Data in this record has been reviewed and will be made open in the future, in support of the
+            <a href="http://www.ontario.ca/page/ontarios-open-data-directive">Open Data Directive</a>.
+          </p>
+        {% endtrans %}
+      {% endif %}
+    <hr />
+  {% endif %}
 {% endblock %}
 
 {% block package_additional_info %}

--- a/ckanext/ontario_theme/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/ontario_theme/templates/scheming/package/snippets/additional_info.html
@@ -10,6 +10,10 @@
     'owner_org',
     'notes_translated',
     'short_description',
+    'access_level',
+    'opened_date',
+    'exemption',
+    'exemption_rationale',
     'title_translated'
     ] -%}
 


### PR DESCRIPTION
This PR consists of 1 commit and 1 change. The dataset status snippet from the current catalogue was implement in the new catalogue to pull access_level, exemption, exemption_rationale, and opened_data from the additional_info html snippet and display it in the read html snippet.