### PR TITLE
Bug: Fix the 'tell us what you think' link on homepage

### DIFF
--- a/ckanext/ontario_theme/templates/home/snippets/ontario_theme_intro.html
+++ b/ckanext/ontario_theme/templates/home/snippets/ontario_theme_intro.html
@@ -27,7 +27,7 @@ help users better understand the data catalogue
   <div class="col-md-4">
     <h2><i class="fa fa-bullhorn large pull-left"></i> {% trans %}Provide feedback{% endtrans %}</h2>
     <p>
-      {% trans %}As we work to develop the catalogue, <a href=\"mailto:opengov@ontario.ca\">tell us what you think</a>.{% endtrans %}
+      {% trans %}As we work to develop the catalogue, <a href="mailto:opengov@ontario.ca">tell us what you think</a>.{% endtrans %}
     </p>
   </div>
 </div>


### PR DESCRIPTION
This PR consists of one change and one commit, just fixing the bug in the url for the 'tell us what you think' link on the homepage.