### PR TITLE
Task: Add public catalogue id field to Colby

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -599,6 +599,16 @@
       "display_snippet": null,
       "form_placeholder": "4321",
       "validators": "ignore_missing int_validator"
+    },
+    {
+      "field_name": "public_id",
+      "label": {
+        "en": "Ontario data catalogue ID",
+        "fr": "ID du catalogue de données de l'Ontario"
+      },
+      "form_snippet": null,
+      "display_snippet": null,
+      "validators": "ignore_missing"
     }
   ],
   "resource_fields": [


### PR DESCRIPTION
This PR consists of one change and one commit: In order to link the colby and public catalogue records together, a field to store the public catalogue id needs to be added to colby.