### PR TITLE
Task: Re-add groups link to main menu.

### DIFF
--- a/ckanext/ontario_theme/templates/header.html
+++ b/ckanext/ontario_theme/templates/header.html
@@ -87,6 +87,7 @@
         {{ h.build_nav_main(
           ('search', _('Datasets')),
           ('organizations_index', _('Organizations')),
+          ('group_index', _('Groups')),          
           ('home.about', _('About')),
           ('ontario_theme.help', _('Help'))
         ) }}


### PR DESCRIPTION
Originally, groups were providing no function in Colby, but there is intent to use them in Colby and the public catalogue, so it's being readded.