### PR TITLE
Odc beta add language disclaimer

### DIFF
--- a/ckanext/ontario_theme/fanstatic/alerts.less
+++ b/ckanext/ontario_theme/fanstatic/alerts.less
@@ -1,4 +1,4 @@
-.alert {
+.new-alert {
     border-color: rgba(0,0,0,.1);
     border-width: 0 0 0 .9375rem;
     border-style: solid;

--- a/ckanext/ontario_theme/fanstatic/alerts.less
+++ b/ckanext/ontario_theme/fanstatic/alerts.less
@@ -1,0 +1,61 @@
+.alert {
+    border-color: rgba(0,0,0,.1);
+    border-width: 0 0 0 .9375rem;
+    border-style: solid;
+    padding: .9375rem 2rem .9375rem .9375rem;
+    color: #333;
+    border-radius: 0px;
+    min-height: 50px;
+    padding-left: 70px;
+    padding-top: 15px;
+    position: relative;
+    &.alert-success::before, &.alert-info::before, &.alert-warning::before, &.alert-danger::before, &.alert-open::before, &.alert-tobeopened::before, &.alert-underreview::before, &.alert-restricted::before {
+        font-family:"FontAwesome";
+        font-size: 36px;
+        position: absolute;
+        padding-right: 10px;
+        padding-left: 10px;
+        margin-top: -10px;
+        left: 10px;
+        top: 10px;
+    }
+    &.alert-success::before {
+        content:"\f058";
+        color: #2B8737;
+      }
+    &.alert-info::before {
+        content:"\f05a";
+        color: #0369AC;
+    }
+    &.alert-warning::before {
+        content:"\f06a";
+        color: #8A600D;
+    }
+    &.alert-danger::before {
+        content:"\f057";
+        color: #D81A21;
+    }
+    &.alert-open::before {
+        content:"\f058";
+        color: #2B8737;
+    }
+    &.alert-tobeopened::before {
+        content:"\f017";
+        color: #0369AC;       
+    }
+    &.alert-underreview::before {
+        content:"\f059";
+        color: #8A600D;
+    }
+    &.alert-restricted::before {
+        content:"\f023";
+        color: #D81A21;   
+    }
+    &.alert-large {
+        min-height: 80px;
+        padding-left: 90px;
+        &.alert-success::before, &.alert-info::before, &.alert-warning::before, &.alert-danger::before, &.alert-open::before, &.alert-tobeopened::before, &.alert-underreview::before, &.alert-restricted::before {
+            font-size: 60px;
+        }
+    }
+}

--- a/ckanext/ontario_theme/fanstatic/labels.less
+++ b/ckanext/ontario_theme/fanstatic/labels.less
@@ -73,23 +73,3 @@
   height: 35px;
   background-position: -414px -62px;
 }
-
-.open,.under_review,.to_be_opened,.restricted {
-  color: #4d4d4d;
-}
-
-.open {
-  background-color: #e6fad2;
-}
-
-.under_review {
-  background: #d2d1eb;
-}
-
-.to_be_opened {
-  background-color: #dff3f3
-}
-
-.restricted {
-  background-color: #fad2d2;
-}

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -1,4 +1,4 @@
-.alert {
+.new-alert {
   border-color: rgba(0, 0, 0, 0.1);
   border-width: 0 0 0 .9375rem;
   border-style: solid;
@@ -10,14 +10,14 @@
   padding-top: 15px;
   position: relative;
 }
-.alert.alert-success::before,
-.alert.alert-info::before,
-.alert.alert-warning::before,
-.alert.alert-danger::before,
-.alert.alert-open::before,
-.alert.alert-tobeopened::before,
-.alert.alert-underreview::before,
-.alert.alert-restricted::before {
+.new-alert.alert-success::before,
+.new-alert.alert-info::before,
+.new-alert.alert-warning::before,
+.new-alert.alert-danger::before,
+.new-alert.alert-open::before,
+.new-alert.alert-tobeopened::before,
+.new-alert.alert-underreview::before,
+.new-alert.alert-restricted::before {
   font-family: "FontAwesome";
   font-size: 36px;
   position: absolute;
@@ -27,50 +27,50 @@
   left: 10px;
   top: 10px;
 }
-.alert.alert-success::before {
+.new-alert.alert-success::before {
   content: "\f058";
   color: #2B8737;
 }
-.alert.alert-info::before {
+.new-alert.alert-info::before {
   content: "\f05a";
   color: #0369AC;
 }
-.alert.alert-warning::before {
+.new-alert.alert-warning::before {
   content: "\f06a";
   color: #8A600D;
 }
-.alert.alert-danger::before {
+.new-alert.alert-danger::before {
   content: "\f057";
   color: #D81A21;
 }
-.alert.alert-open::before {
+.new-alert.alert-open::before {
   content: "\f058";
   color: #2B8737;
 }
-.alert.alert-tobeopened::before {
+.new-alert.alert-tobeopened::before {
   content: "\f017";
   color: #0369AC;
 }
-.alert.alert-underreview::before {
+.new-alert.alert-underreview::before {
   content: "\f059";
   color: #8A600D;
 }
-.alert.alert-restricted::before {
+.new-alert.alert-restricted::before {
   content: "\f023";
   color: #D81A21;
 }
-.alert.alert-large {
+.new-alert.alert-large {
   min-height: 80px;
   padding-left: 90px;
 }
-.alert.alert-large.alert-success::before,
-.alert.alert-large.alert-info::before,
-.alert.alert-large.alert-warning::before,
-.alert.alert-large.alert-danger::before,
-.alert.alert-large.alert-open::before,
-.alert.alert-large.alert-tobeopened::before,
-.alert.alert-large.alert-underreview::before,
-.alert.alert-large.alert-restricted::before {
+.new-alert.alert-large.alert-success::before,
+.new-alert.alert-large.alert-info::before,
+.new-alert.alert-large.alert-warning::before,
+.new-alert.alert-large.alert-danger::before,
+.new-alert.alert-large.alert-open::before,
+.new-alert.alert-large.alert-tobeopened::before,
+.new-alert.alert-large.alert-underreview::before,
+.new-alert.alert-large.alert-restricted::before {
   font-size: 60px;
 }
 /* =====================================================

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -1,3 +1,78 @@
+.alert {
+  border-color: rgba(0, 0, 0, 0.1);
+  border-width: 0 0 0 .9375rem;
+  border-style: solid;
+  padding: .9375rem 2rem .9375rem .9375rem;
+  color: #333;
+  border-radius: 0px;
+  min-height: 50px;
+  padding-left: 70px;
+  padding-top: 15px;
+  position: relative;
+}
+.alert.alert-success::before,
+.alert.alert-info::before,
+.alert.alert-warning::before,
+.alert.alert-danger::before,
+.alert.alert-open::before,
+.alert.alert-tobeopened::before,
+.alert.alert-underreview::before,
+.alert.alert-restricted::before {
+  font-family: "FontAwesome";
+  font-size: 36px;
+  position: absolute;
+  padding-right: 10px;
+  padding-left: 10px;
+  margin-top: -10px;
+  left: 10px;
+  top: 10px;
+}
+.alert.alert-success::before {
+  content: "\f058";
+  color: #2B8737;
+}
+.alert.alert-info::before {
+  content: "\f05a";
+  color: #0369AC;
+}
+.alert.alert-warning::before {
+  content: "\f06a";
+  color: #8A600D;
+}
+.alert.alert-danger::before {
+  content: "\f057";
+  color: #D81A21;
+}
+.alert.alert-open::before {
+  content: "\f058";
+  color: #2B8737;
+}
+.alert.alert-tobeopened::before {
+  content: "\f017";
+  color: #0369AC;
+}
+.alert.alert-underreview::before {
+  content: "\f059";
+  color: #8A600D;
+}
+.alert.alert-restricted::before {
+  content: "\f023";
+  color: #D81A21;
+}
+.alert.alert-large {
+  min-height: 80px;
+  padding-left: 90px;
+}
+.alert.alert-large.alert-success::before,
+.alert.alert-large.alert-info::before,
+.alert.alert-large.alert-warning::before,
+.alert.alert-large.alert-danger::before,
+.alert.alert-large.alert-open::before,
+.alert.alert-large.alert-tobeopened::before,
+.alert.alert-large.alert-underreview::before,
+.alert.alert-large.alert-restricted::before {
+  font-size: 60px;
+}
 /* =====================================================
    Generic classes for Colby colours
    ===================================================== */
@@ -317,21 +392,6 @@ div.card p {
   width: 31px;
   height: 35px;
   background-position: -414px -62px;
-}
-.open,.under_review,.to_be_opened,.restricted {
-  color: #4d4d4d;
-}
-.open {
-  background-color: #e6fad2;
-}
-.under_review {
-  background: #d2d1eb;
-}
-.to_be_opened {
-  background-color: #dff3f3
-}
-.restricted {
-  background-color: #fad2d2;
 }
 .stats .number {
   display: block;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -1,3 +1,4 @@
+@import "alerts.less";
 @import "colours.less";
 @import "activity.less";
 @import "accessibility.less";

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -6,6 +6,7 @@
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
+  {% snippet 'package/snippets/ontario_theme_language_disclaimer.html', pkg=pkg, res=res %}
 {% endblock %}
 
 {% block resource_actions_inner %}

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -1,5 +1,13 @@
 {% ckan_extends %}
 
+{% block resource_read_url %}
+  {% if res.url and h.is_url(res.url) %}
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+  {% elif res.url %}
+    <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
+  {% endif %}
+{% endblock %}
+
 {% block resource_actions_inner %}
 {% if h.check_access('package_update', {'id':pkg.id }) %}
   <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>

--- a/ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html
+++ b/ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html
@@ -1,0 +1,23 @@
+{#
+  Custom language notification in the cases that users are viewing the site in one language and a resource in another
+#}
+{% set current_lang = request.environ.CKAN_LANG %}
+{% if (res.language == "english" and current_lang == "fr") or (res.language == "french" and current_lang == "en") %}
+  <div class="new-alert alert-warning alert-large">
+  {% if pkg.resources|selectattr("language", "equalto","english")|selectattr("type", "equalto", "data")|list|length > 0 %}
+    {% trans url=h.url_for(controller='package', action='read', id=c.package['name']) %}
+      You're viewing a data file in French.
+      This dataset has files available in English.
+      <a href="{{ url }}#dataset-resources">Click here</a>
+       to go back and select a file in English.
+    {% endtrans %}
+  {% else %}
+    {% trans %}
+      You're viewing a data file in French. 
+      This dataset <strong>does not</strong> have files available in English. 
+      Data on the data catalogue is published in the language in which it’s collected. 
+      <a href="https://www.ontario.ca/page/ontarios-open-data-directive">[Learn more]</a>
+    {% endtrans %}
+  {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
This PR consists of 3 commits to make 1 change: the addition of a language disclaimer on the resource page that displays in 4 cases:

- you're viewing the site in french and looking at an english only resource. there are french resources available.
- you're viewing the site in french and looking at an english only resource. there are no french resources available.
- you're viewing the site in english and looking at a french only resource. there are english resources available.
- you're viewing the site in english and looking at a french only resource. there are no english resources available.