### PR TITLE
Bug: fluent notation mis-applied.

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -162,7 +162,7 @@
       "classes": ["col-md-12","form-group"]
     },
     {
-      "field_name": "maintainer",
+      "field_name": "maintainer_translated",
       "label": {
         "en": "Maintainer",
         "fr": "Mainteneur"
@@ -172,6 +172,7 @@
       "help_text": {
         "en": "Name of a person or organization within the OPS that can be contacted about the resource"
       },
+      "preset" : "fluent_core_translated",
       "form_placeholder": "e.g., Joe Bloggs",
       "display_property": "dc:contributor",
       "classes": ["col-md-12","form-group"]
@@ -365,7 +366,7 @@
       ]
     }, 
     {
-      "field_name": "access_instructions_translated",
+      "field_name": "access_instructions",
       "label": {
         "en": "Access instructions",
         "fr": "Instructions d'accès"
@@ -378,8 +379,7 @@
         "en": "Explain any additional steps needed to access the resource"
       },
       "classes": ["form-group","col-md-12"],
-      "preset": "fluent_core_translated",
-      "form_snippet": "fluent_markdown.html",
+      "preset": "fluent_markdown",
       "form_placeholder": "e.g., Users will need to register with the website to recieve a login and provide an email address. Visit http://www.example.com/register."
     },
     {


### PR DESCRIPTION
This PR consists of changes to:
 - remove "_translated" from non-core fields in the schema
 - add "_translated" to core fields in the schema
 - use "preset" instead of referring to form_snippet and display_snippet 

Note: Further PRs must change use of get_translated to scheming_language_text (or similar) to resolve this issue.