### PR TITLE
Specific dataset atom feed doesn't work.

### DIFF
--- a/ckanext/ontario_theme/templates/home/help.html
+++ b/ckanext/ontario_theme/templates/home/help.html
@@ -221,11 +221,11 @@
             {% trans %}A specific dataset is updated{% endtrans %}
             <br />
             <strong>
-              RSS URL: data.ontario.ca/feeds/dataset.atom?id=[{% trans %}name-of-specific-dataset{% endtrans %}]
+              RSS URL: data.ontario.ca/feeds/custom.atom?q=name:[{% trans %}name-of-specific-dataset{% endtrans %}]
             </strong>
             <br />
             <em>
-              {% trans %}Example{% endtrans %}: data.ontario.ca/feeds/dataset.atom?id=zooplankton-monitoring
+              {% trans %}Example{% endtrans %}: data.ontario.ca/feeds/custom.atom?q=name:zooplankton-monitoring
             </em>
           </li>
           <li>


### PR DESCRIPTION
Specific dataset atom feed given in the documentation doesn't work. This was replaced with the custom.atom feed and passing the name.