### PR TITLE
Odc beta missing fr translations

### DIFF
--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -756,6 +756,11 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
+#: ckan/templates/package/resource_read.html:88
+#, python-format
+msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
+msgstr ""
+
 #: ckanext/ontario_theme/templates/package/resource_read.html:18
 #: ckanext/ontario_theme/templates/package/snippets/resource_item.html:32
 msgid "Download"

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -824,6 +824,10 @@ msgid ""
 "more]</a> </p> "
 msgstr ""
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
+msgid "Covers"
+msgstr ""
+
 #: ckanext/ontario_theme/templates/snippets/search_form.html:29
 msgid "Keywords"
 msgstr ""

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -824,6 +824,22 @@ msgid ""
 "more]</a> </p> "
 msgstr ""
 
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html:8
+#, python-format
+msgid ""
+" You're viewing a data file in French. This dataset has files available in "
+"English. <a href=\"%(url)s#dataset-resources\">Click here</a> to go back and "
+"select a file in English. "
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html:15
+msgid ""
+" You're viewing a data file in French. This dataset <strong>does not</strong>"
+" have files available in English. Data on the data catalogue is published in "
+"the language in which it’s collected. <a href=\"https://www.ontario.ca/page"
+"/ontarios-open-data-directive\">[Learn more]</a> "
+msgstr ""
+
 #: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
 msgid "Covers"
 msgstr ""

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -641,7 +641,7 @@ msgid "Search datasets"
 msgstr ""
 
 #: ckanext/ontario_theme/templates/home/snippets/search.html:21
-msgid "Popular tags"
+msgid "Popular keywords"
 msgstr ""
 
 #: ckanext/ontario_theme/templates/macros/form.html:126
@@ -866,7 +866,11 @@ msgstr ""
 
 #: ckanext/ontario_theme/templates/snippets/search_form.html:29
 msgid "Update Frequency"
-msgstr "r"
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/resource_read.html:25
+msgid "Open"
+msgstr ""
 
 #: ckanext/ontario_theme/templates/package/search.html:34
 msgid "Popular"
@@ -899,6 +903,10 @@ msgstr ""
 
 #: ckanext/ontario_theme/templates/scheming/form_snippets/_organization_select.html:21
 msgid "No organization"
+msgstr ""
+
+#: ckanext/ontario_theme/templates/scheming/package/read.html:24
+msgid "Contact"
 msgstr ""
 
 #: ckanext/ontario_theme/templates/scheming/package/resource_read.html:5

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -777,6 +777,53 @@ msgstr ""
 msgid "Datasets with data"
 msgstr ""
 
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:9
+msgid "Data Available"
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:11
+#, python-format
+msgid ""
+" The data described here is available for you to use. <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a><br /> <a href=\"%(license_url)s\">[See the licence for how you're "
+"allowed to use this data.]</a> "
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:17
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:31
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:39
+msgid "Data Not Available"
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:19
+msgid ""
+" This data is not and will not be made available. Data in this record cannot "
+"be released because of legal, privacy, security, confidentiality or "
+"commercially-sensitive reasons, as outlined by the <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">Open Data "
+"Directive</a>. "
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:27
+msgid "Why?"
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:33
+msgid ""
+" This data might be made available in the future. We are reviewing the data "
+"in this record to determine if it can be made open. <a "
+"href=\"http://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a> "
+msgstr ""
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:40
+msgid ""
+" <p> This data will be made open in the future after it has been approved. <a"
+" href=\"http://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a> </p> "
+msgstr ""
+
 #: ckanext/ontario_theme/templates/snippets/search_form.html:29
 msgid "Keywords"
 msgstr ""

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -844,6 +844,10 @@ msgstr ""
 msgid "Covers"
 msgstr ""
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:33
+msgid "Supporting Files"
+msgstr "Autres fichiers"
+
 #: ckanext/ontario_theme/templates/snippets/search_form.html:29
 msgid "Keywords"
 msgstr ""

--- a/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
+++ b/ckanext/ontario_theme/i18n/ckanext-ontario_theme.pot
@@ -845,6 +845,10 @@ msgid ""
 "/ontarios-open-data-directive\">[Learn more]</a> "
 msgstr ""
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:17
+msgid "No date range"
+msgstr ""
+
 #: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
 msgid "Covers"
 msgstr ""

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -36,6 +36,16 @@ msgstr "conditions d’utilisation"
 msgid "&copy; Queen&#8217;s Printer for Ontario"
 msgstr "&copy; Imprimeur de la Reine pour l’Ontario"
 
+#: ckanext/ontario_theme/templates/footer.html:21
+msgid ""
+"<strong>Powered by</strong> <a class=\"hide-text ckan-footer-logo\" "
+"href=\"http://ckan.org\"><abbr title=\"Comprehensive Knowledge Archive "
+"Network\">CKAN</abbr></a>"
+msgstr ""
+"<strong>Généré par</strong> <a class=\"hide-text ckan-footer-logo\" "
+"href=\"http://ckan.org\"><abbr title=\"Comprehensive Knowledge Archive "
+"Network\">CKAN</abbr></a>"
+
 #: ckanext/ontario_theme/templates/header.html:89
 #: ckanext/ontario_theme/templates/home/help.html:3
 #: ckanext/ontario_theme/templates/home/help.html:6

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -621,6 +621,23 @@ msgstr ""
 "href=\"https://www.ontario.ca/fr/page/directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre "
 "encore plus]</a> "
 
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html:8
+#, python-format
+msgid ""
+" You're viewing a data file in French. This dataset has files available in "
+"English. <a href=\"%(url)s#dataset-resources\">Click here</a> to go back and "
+"select a file in English. "
+msgstr "Vous consultez un fichier de données en anglais. Cet ensemble de données contient des fichiers disponibles en français. <a href=\"%(url)s#dataset-resources\">Cliquez ici</a> pour revenir en arrière et sélectionner un fichier en français."
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_language_disclaimer.html:15
+msgid ""
+" You're viewing a data file in French. This dataset <strong>does not</strong>"
+" have files available in English. Data on the data catalogue is published in "
+"the language in which it’s collected. <a href=\"https://www.ontario.ca/page"
+"/ontarios-open-data-directive\">[Learn more]</a> "
+msgstr "Vous consultez un fichier de données en anglais. Cet ensemble de données <strong>n'a </strong> aucun fichier disponible en français. Les données du catalogue de données sont publiées dans la langue dans laquelle elles sont collectées. <a href=\"https://www.ontario.ca/fr/page/"
+"directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre encore plus]</a>"
+
 #: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
 msgid "Covers"
 msgstr "Pour la période de"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -558,6 +558,69 @@ msgstr "Récemment créé"
 msgid "Datasets with data"
 msgstr "Jeux de données avec données"
 
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:9
+msgid "Data Available"
+msgstr "Données disponibles"
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:11
+#, python-format
+msgid ""
+" The data described here is available for you to use. <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a><br /> <a href=\"%(license_url)s\">[See the licence for how you're "
+"allowed to use this data.]</a> "
+msgstr ""
+" Les données décrites ici sont disponibles pour votre utilisation. <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">[Apprendre "
+"encore plus]</a><br /> <a href=\"%(license_url)s\">[Voir la licence pour savoir comment vous "
+"êtes autorisé à utiliser ces données.]</a> "
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:17
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:31
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:39
+msgid "Data Not Available"
+msgstr "Données non disponibles"
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:19
+msgid ""
+" This data is not and will not be made available. Data in this record cannot "
+"be released because of legal, privacy, security, confidentiality or "
+"commercially-sensitive reasons, as outlined by the <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">Open Data "
+"Directive</a>. "
+msgstr ""
+" Ces données ne sont pas et ne seront pas mises à disposition. Les données contenues dans ce dossier ne peuvent "
+"être divulguées pour des motifs d’application de la loi, de protection des renseignements personnels, "
+"de sécurité ou de secret commercial, comme il est énoncé dans la <a "
+"href=\"https://www.ontario.ca/page/ontarios-open-data-directive\">Directive sur "
+"les données ouvertes de l'Ontario</a>. "
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:27
+msgid "Why?"
+msgstr "Pourqoui"
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:33
+msgid ""
+" This data might be made available in the future. We are reviewing the data "
+"in this record to determine if it can be made open. <a "
+"href=\"http://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a> "
+msgstr ""
+" Ces données pourraient être mises à disposition à l'avenir. Nous sommes en train d’examiner "
+"les données de cette série pour déterminer si elles peuvent être ouvertes. <a "
+"href=\"https://www.ontario.ca/fr/page/directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre "
+"encore plus]</a> "
+
+#: ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html:40
+msgid ""
+" <p> This data will be made open in the future after it has been approved. <a"
+" href=\"http://www.ontario.ca/page/ontarios-open-data-directive\">[Learn "
+"more]</a> </p> "
+msgstr ""
+" <p> Ces données seront rendues publiques à l'avenir après leur approbation. <a"
+"href=\"https://www.ontario.ca/fr/page/directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre "
+"encore plus]</a> "
+
 #: ckanext/ontario_theme/templates/scheming/package/read.html:25
 msgid "Ontario's Open Data Team"
 msgstr "L'équipe de données ouvertes de l'Ontario"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -642,6 +642,10 @@ msgstr "Vous consultez un fichier de données en anglais. Cet ensemble de donné
 msgid "Covers"
 msgstr "Pour la période de"
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:33
+msgid "Supporting Files"
+msgstr "Autres fichiers"
+
 #: ckanext/ontario_theme/templates/scheming/package/read.html:25
 msgid "Ontario's Open Data Team"
 msgstr "L'équipe de données ouvertes de l'Ontario"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -621,6 +621,10 @@ msgstr ""
 "href=\"https://www.ontario.ca/fr/page/directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre "
 "encore plus]</a> "
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
+msgid "Covers"
+msgstr "Pour la période de"
+
 #: ckanext/ontario_theme/templates/scheming/package/read.html:25
 msgid "Ontario's Open Data Team"
 msgstr "L'équipe de données ouvertes de l'Ontario"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -535,6 +535,10 @@ msgstr "Activité récente"
 msgid "E.g. environment"
 msgstr "par exemple, environnement"
 
+#: ckanext/ontario_theme/templates/home/snippets/search.html:21
+msgid "Popular keywords"
+msgstr "Mots-clés populaires"
+
 #: ckanext/ontario_theme/templates/macros/form.html:233
 msgid "Key"
 msgstr ""
@@ -549,6 +553,10 @@ msgid ""
 "its datasets. </p> "
 msgstr "Trouvez une liste des ministères de l'Ontario ici. Cliquez sur un ministère pour voir "
 "ses jeux de données."
+
+#: ckanext/ontario_theme/templates/package/resource_read.html:25
+msgid "Open"
+msgstr "Ouvert"
 
 #: ckanext/ontario_theme/templates/package/search.html:32
 msgid "Recently Created"
@@ -645,6 +653,10 @@ msgstr "Pour la période de"
 #: ckanext/ontario_theme/templates/package/snippets/resources_list.html:33
 msgid "Supporting Files"
 msgstr "Autres fichiers"
+
+#: ckanext/ontario_theme/templates/scheming/package/read.html:24
+msgid "Contact"
+msgstr "Contactez-nous"
 
 #: ckanext/ontario_theme/templates/scheming/package/read.html:25
 msgid "Ontario's Open Data Team"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -661,6 +661,10 @@ msgid ""
 msgstr "Vous consultez un fichier de données en anglais. Cet ensemble de données <strong>n'a </strong> aucun fichier disponible en français. Les données du catalogue de données sont publiées dans la langue dans laquelle elles sont collectées. <a href=\"https://www.ontario.ca/fr/page/"
 "directive-sur-les-donnees-ouvertes-de-lontario\">[Apprendre encore plus]</a>"
 
+#: ckanext/ontario_theme/templates/package/snippets/resources_list.html:17
+msgid "No date range"
+msgstr "Pas de intervalle"
+
 #: ckanext/ontario_theme/templates/package/snippets/resources_list.html:20
 msgid "Covers"
 msgstr "Pour la période de"

--- a/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
+++ b/ckanext/ontario_theme/i18n/fr/LC_MESSAGES/ckanext-ontario_theme.po
@@ -558,6 +558,11 @@ msgstr "Trouvez une liste des ministères de l'Ontario ici. Cliquez sur un minis
 msgid "Open"
 msgstr "Ouvert"
 
+#: ckan/templates/package/resource_read.html:88
+#, python-format
+msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
+msgstr "L'origine: <a href=\"%(url)s\">%(dataset)s</a>"
+
 #: ckanext/ontario_theme/templates/package/search.html:32
 msgid "Recently Created"
 msgstr "Récemment créé"

--- a/ckanext/ontario_theme/templates/scheming/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/scheming/package/resource_read.html
@@ -26,7 +26,7 @@
     {% if not res.description and c.package.notes %}
       <h3>{{ _('From the dataset abstract') }}</h3>
       <blockquote>{{ h.markdown_extract(h.get_translated(c.package, 'notes')) }}</blockquote>
-      <p>{% trans dataset=c.package.title, url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
+      <p>{% trans dataset=h.get_translated(c.package, "title"), url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR consists of 8 commits for the following translation fixes:
- Missing translations for 
  - access level content
  - 'covers', 'contact', 'popular keywords', 'supporting files', 'open', and 'no date range'
  - language disclaimers. 
  - 'Source' line on resource read page doesn't translate. …
  - 'Powered by' (broken by the addition of a <abbr>