### PR TITLE
Task: Analytics css selectors

### DIFF
--- a/ckanext/ontario_theme/templates/organization/read_base.html
+++ b/ckanext/ontario_theme/templates/organization/read_base.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
-  <li class="active">{% link_for h.get_translated(c.group_dict,"title")|truncate(35), controller='organization', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
+  <li id="ministry-name" ministry-name="{{c.group_dict.title}}" class="active">{% link_for h.get_translated(c.group_dict,"title")|truncate(35), controller='organization', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckanext/ontario_theme/templates/package/base.html
+++ b/ckanext/ontario_theme/templates/package/base.html
@@ -7,11 +7,11 @@
       {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
       {% set group_type = pkg.organization.type %}
       <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
-      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
+      <li id='ministry-name' ministry-name="{{pkg.organization.title}}">{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
     {% else %}
       <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     {% endif %}
-    <li {{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), controller='package', action='read', id=pkg.name %}</li>
+    <li id='dataset-name' dataset-name="{{pkg.title}}" {{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), controller='package', action='read', id=pkg.name %}</li>
   {% else %}
     <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>

--- a/ckanext/ontario_theme/templates/package/base.html
+++ b/ckanext/ontario_theme/templates/package/base.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content %}
+  {% if pkg %}
+    {% set dataset = h.dataset_display_name(pkg) %}
+    {% if pkg.organization %}
+      {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% set group_type = pkg.organization.type %}
+      <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
+      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
+    {% else %}
+      <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
+    {% endif %}
+    <li {{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), controller='package', action='read', id=pkg.name %}</li>
+  {% else %}
+    <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
+    <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>
+  {% endif %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/resource_read.html
+++ b/ckanext/ontario_theme/templates/package/resource_read.html
@@ -2,7 +2,7 @@
 
 {% block resource_read_url %}
   {% if res.url and h.is_url(res.url) %}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics dataset-download-link" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}
@@ -16,7 +16,7 @@
 {% if res.url and h.is_url(res.url) %}
   <li>
     <div class="btn-group">
-    <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+    <a class="btn btn-primary dataset-download-link resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
       {% if res.resource_type in ('listing', 'service') %}
         <i class="fa fa-eye"></i> {{ _('View') }}
       {% elif  res.resource_type == 'api' %}
@@ -34,13 +34,13 @@
       </button>
     <ul class="dropdown-menu">
       <li>
-        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
+        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
           target="_blank"><span>CSV</span></a>
-        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
+        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
           target="_blank"><span>TSV</span></a>
-        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
+        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
           target="_blank"><span>JSON</span></a>
-        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
+        <a class="dataset-download-link" href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
           target="_blank"><span>XML</span></a>
       </li>
     </ul>

--- a/ckanext/ontario_theme/templates/package/snippets/resource_item.html
+++ b/ckanext/ontario_theme/templates/package/snippets/resource_item.html
@@ -56,7 +56,7 @@
               {% endif %}
             </a>
           {% if res.url and h.is_url(res.url) %}
-            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary" target="_blank">
+            <a href="{{ res.url }}" class="resource-url-analytics btn btn-primary dataset-download-link" target="_blank">
               {% if res.has_views or res.url_type == 'upload' %}
                 <i class="fa fa-arrow-circle-o-down"></i>
                 {{ _('Download') }}


### PR DESCRIPTION
This PR consists of 2 commits to make the following changes:
* create a ministry-name id and attribute to use for analytics and roll up stats per ministry
* add a class to download and open buttons, resource url, and 'download as [format]' links in order to be able to roll up all resource downloads in analytics
* create a ministry-name id and attribute to dataset and resource pages so stats can be rolled up by dataset