### PR TITLE
Odc beta remove follow feature

### DIFF
--- a/ckanext/ontario_theme/templates/group/snippets/info.html
+++ b/ckanext/ontario_theme/templates/group/snippets/info.html
@@ -3,10 +3,6 @@
 {% block nums %}
   <div class="nums">
     <dl>
-      <dt>{{ _('Followers') }}</dt>
-      <dd data-module="followers-counter" data-module-id="{{ group.id }}" data-module-num_followers="{{ group.num_followers }}">{{ h.SI_number_span(group.num_followers) }}</dd>
-    </dl>
-    <dl>
       <dt>{{ _('Datasets') }}</dt>
       <dd>{{ h.SI_number_span(group.package_count) }}</dd>
     </dl>
@@ -14,7 +10,4 @@
 {% endblock %}
 
 {% block follow %}
-  <div class="follow_button">
-    {{ h.follow_button('group', group.id) }}
-  </div>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/group/snippets/info.html
+++ b/ckanext/ontario_theme/templates/group/snippets/info.html
@@ -1,0 +1,20 @@
+{% ckan_extends %}
+
+{% block nums %}
+  <div class="nums">
+    <dl>
+      <dt>{{ _('Followers') }}</dt>
+      <dd data-module="followers-counter" data-module-id="{{ group.id }}" data-module-num_followers="{{ group.num_followers }}">{{ h.SI_number_span(group.num_followers) }}</dd>
+    </dl>
+    <dl>
+      <dt>{{ _('Datasets') }}</dt>
+      <dd>{{ h.SI_number_span(group.package_count) }}</dd>
+    </dl>
+  </div>
+{% endblock %}
+
+{% block follow %}
+  <div class="follow_button">
+    {{ h.follow_button('group', group.id) }}
+  </div>
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -5,3 +5,7 @@
     {% link_for _('Edit'), controller='package', action='edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
+
+{% block package_info %}
+  {% snippet 'package/snippets/info.html', pkg=pkg %}
+{% endblock %}

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -7,5 +7,4 @@
 {% endblock %}
 
 {% block package_info %}
-  {% snippet 'package/snippets/info.html', pkg=pkg %}
 {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/snippets/organization.html
@@ -22,17 +22,10 @@
 {% block nums %}
   <div class="nums">
     <dl>
-      <dt>{{ _('Followers') }}</dt>
-      <dd data-module="followers-counter" data-module-id="{{ organization.id }}" data-module-num_followers="{{ organization.num_followers }}">{{ h.SI_number_span(organization.num_followers) }}</dd>
-    </dl>
-    <dl>
       <dt>{{ _('Datasets') }}</dt>
       <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
     </dl>
   </div>
 {% endblock %}
 {% block follow %}
-  <div class="follow_button">
-    {{ h.follow_button('group', organization.id) }}
-  </div>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/snippets/organization.html
@@ -18,3 +18,21 @@
     <p class="empty">{{ _('There is no description for this organization') }}</p>
   {% endif %}
 {% endblock %}
+
+{% block nums %}
+  <div class="nums">
+    <dl>
+      <dt>{{ _('Followers') }}</dt>
+      <dd data-module="followers-counter" data-module-id="{{ organization.id }}" data-module-num_followers="{{ organization.num_followers }}">{{ h.SI_number_span(organization.num_followers) }}</dd>
+    </dl>
+    <dl>
+      <dt>{{ _('Datasets') }}</dt>
+      <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
+    </dl>
+  </div>
+{% endblock %}
+{% block follow %}
+  <div class="follow_button">
+    {{ h.follow_button('group', organization.id) }}
+  </div>
+{% endblock %}


### PR DESCRIPTION
This PR consists of 6 commits to make 3 changes:

* remove followers feature from
   * group page (read)
   * organization page (read)
   * package page (read)

This is because the followers feature is only available to users that are logged in, but user accounts will be used only to maintain the catalogue, not to view it.