### PR TITLE
Task: Add link to Open Data Guidebook for exemption field.

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -496,7 +496,7 @@
       },
       "help_inline" : true,
       "help_text": {
-        "en": "What is the specific exemption for this collection of resources to not be shared with the public? Refer to [link to ODD] for list of acceptable exemptions"
+        "en": "What is the specific exemption for this collection of resources to not be shared with the public? Refer to the <a href='https://www.ontario.ca/document/open-data-guidebook-guide-open-data-directive-2015/data-inventory#section-1' target='_blank'>Open Data Guidebook</a> for more on exemptions."
       },
       "classes": ["form-group","col-md-12"],
       "preset": "select",

--- a/ckanext/ontario_theme/templates/scheming/form_snippets/help_text.html
+++ b/ckanext/ontario_theme/templates/scheming/form_snippets/help_text.html
@@ -1,0 +1,8 @@
+{% import 'macros/form.html' as form %}
+
+{%- if field.help_text -%}
+    {{- form.info(
+        text=h.render_markdown(h.scheming_language_text(field.help_text), True, True),
+        inline=field.get('help_inline', false)
+        ) -}}
+{%- endif -%}


### PR DESCRIPTION
This PR includes one commit to make two changes:

 * add a link to the open data guidebook
 * enable markdown and html for help text in the form so that the link can be opened in a new window 

In order to provide more guidance in the add dataset form, for the exemption field a link to the open data guidebook was added. In order to enable this so that the link could be opened in a new window (since the link is in a form), allow_html is enabled for help text.