### PR TITLE
Task: Remove 'to be opened' option from form.

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -458,13 +458,6 @@
           }
         },
         {
-          "value": "to_be_opened",
-          "label": {
-            "en": "To be opened",
-            "fr": "En voie d’être ouvertes"
-          }
-        },
-        {
           "value": "under_review",
           "label": {
             "en": "Under review",


### PR DESCRIPTION
This PR consists of one commit to make one change:
 * Remove 'to be opened' option from new/edit dataset form.

There will be a complementary commit on odc-beta to remove the UI elements.