### PR TITLE
Remove 'to be opened' panel from UI

### DIFF
--- a/ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html
+++ b/ckanext/ontario_theme/templates/package/snippets/ontario_theme_access_level.html
@@ -35,14 +35,6 @@
           <a href="http://www.ontario.ca/page/ontarios-open-data-directive">[Learn more]</a>
         {% endtrans %}
       </p>
-    {% elif pkg['access_level'] == 'to_be_opened' %}   
-      <strong>{{ _("Data Not Available") }}</strong>   
-      {% trans %}
-        <p>
-          This data will be made open in the future after it has been approved.
-          <a href="http://www.ontario.ca/page/ontarios-open-data-directive">[Learn more]</a>
-        </p>
-      {% endtrans %}
     {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
This PR consists of one commit to make one change:
 * remove the 'to be opened' panel from the dataset page. 

This PR should be applied after the option is removed from the form (PR #123 ) has been applied and after any datasets with a 'to be opened' access level have been converted to 'under review'.