### PR TITLE
Add RSS subscription buttons

### DIFF
--- a/ckanext/ontario_theme/fanstatic/ontario_theme.css
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.css
@@ -657,6 +657,9 @@ li.resource-item div.btn-wrapper {
   border-bottom: none;
   background-color: transparent;
 }
+.module-heading:not(:first-child) {
+  padding-left: 0px;
+}
 .module-narrow {
   margin: 40px 0px;
   background: #fafafa;

--- a/ckanext/ontario_theme/fanstatic/ontario_theme.less
+++ b/ckanext/ontario_theme/fanstatic/ontario_theme.less
@@ -216,6 +216,9 @@ li.resource-item div.btn-wrapper {
   border-top: none;
   border-bottom: none;
   background-color: transparent;  
+  &:not(:first-child) {
+    padding-left: 0px;
+  }
 }
 
 .module-narrow {

--- a/ckanext/ontario_theme/templates/package/read_base.html
+++ b/ckanext/ontario_theme/templates/package/read_base.html
@@ -7,4 +7,17 @@
 {% endblock %}
 
 {% block package_info %}
+  <div class="module module-narrow module-shallow context-info">
+    <h2 class="module-heading">{{ _("Keep updated") }}</h2>
+    <section class="module-content">
+      <p>
+        {{ _("Subscribe to updates to this dataset using RSS.") }}
+      </p>
+      <p>
+        <a href="/feeds/custom.atom?q=name:{{ pkg.name }}" class="btn btn-primary">
+          <i class="fa fa-rss"></i> {{ _('Subscribe') }}
+        </a>
+      </p>
+    </section>
+  </div>
 {% endblock %}

--- a/ckanext/ontario_theme/templates/snippets/organization.html
+++ b/ckanext/ontario_theme/templates/snippets/organization.html
@@ -28,4 +28,14 @@
   </div>
 {% endblock %}
 {% block follow %}
+  <hr />
+  <h2 class="module-heading">{{ _("Keep updated") }}</h2>
+  <p>
+    {{ _("Subscribe to updates to this ministry using RSS.") }}
+  </p>
+  <p>
+    <a href="/feeds/organization/{{ organization.name }}.atom" class="btn btn-primary">
+      <i class="fa fa-rss"></i> {{ _('Subscribe') }}
+    </a>
+  </p>
 {% endblock %}


### PR DESCRIPTION
This PR consists of two changes:
 * adding a RSS subscription button to each package page
 * adding a RSS subscription button to each organization page

This is so that users of the site don't need necessarily go to the help page to find out about RSS subscriptions and so they have a one-click option.