### PR TITLE
Make access level required

### DIFF
--- a/ckanext/ontario_theme/ontario_theme_dataset.json
+++ b/ckanext/ontario_theme/ontario_theme_dataset.json
@@ -401,6 +401,8 @@
         "en": "Access level",
         "fr": "Statut des données"
       },
+      "required": true,
+      "form_include_blank_choice": true,
       "help_inline" : true,
       "fieldset": 6,
       "fieldset_name": "Open Data Catalogue",
@@ -410,7 +412,7 @@
       }, 
       "classes": ["form-group","col-md-12"],
       "preset": "select",
-      "validators": "ignore_missing scheming_choices",
+      "validators": "scheming_choices scheming_required",
       "choices": [
         {
           "value": "open",


### PR DESCRIPTION
Access level is a required piece of information for the public data catalogue.

This PR consists of one change (3 commits) to make access level required. Changing "required" to "true" is not sufficient to assure the right form behaviour, the scheming_required validator must be added. The "form_include_blank_choice" flag was set to "true" will make sure the user doesn't just unknowningly go with a set default value for access_level. 

This establishes preferred behaviour: If the user doesn't see/fill out access level, the validator sends them back.