### PR TITLE
Change new dataset disclaimer

### DIFF
--- a/ckanext/ontario_theme/templates/package/snippets/disclaimer.html
+++ b/ckanext/ontario_theme/templates/package/snippets/disclaimer.html
@@ -8,8 +8,7 @@
   <p>
     <i class="fa fa-info-circle" 
        aria-hidden="true"></i> 
-    By adding or editing this you are confirming that this data / information 
-    is appropriate to share with the OPS.
+    By adding or editing this you are confirming that this data and/or metadata 
+    is appropriate to share with the public.
   </p>
-  <p>Review the <a href="{{ h.url_for('ontario_theme.help') + '#guidebook-posting-data-or-information-on-colby' }}" target="_blank">Posting Guide</a> if you're unsure.</p>
 </div>


### PR DESCRIPTION
The new dataset disclaimer wasn't relevant to the public catalogue.

This PR consists of 1 commit to change the disclaimer to be public catalogue-specific.

Note: when more guidance is available, it can be added.